### PR TITLE
Fb quickstart docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can obtain this file by following these steps:
 ## TL;DR  ... Quick Start 
   1. Clone the repo to a local directory on a machine with docker installed
      
-       `git clobe https://github.com/LabKey/Dockerfile.git`
+       `git clone https://github.com/LabKey/Dockerfile.git`
   1. Copy in the labkey community embedded `.jar` file to the same directory as the repo (see above on how to obtain)
   1. Export the minimal required environment variables or edit and source the quickstart_envs.sh
   

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This repo is a work in progress. Containers created from these sources are untes
 
 To fully use this repo, you will need installed:
 
-- Docker
-- `docker-compose`
+- Docker >= v20.10.9 recommended 
+- `docker-compose` >= v1.29.2 recommended
 - GNU Make
 - GNU Awk
 
@@ -31,9 +31,32 @@ You can obtain this file by following these steps:
   4. Find the `.jar` amongst the uncompressed files
   5. Move/rename the `.jar` file into the root of this repo
 
+## TL;DR  ... Quick Start 
+  1. Clone the repo to a local directory on a machine with docker installed
+     
+       `git clobe https://github.com/LabKey/Dockerfile.git`
+  1. Copy in the labkey community embedded `.jar` file to the same directory as the repo (see above on how to obtain)
+  1. Export the minimal required environment variables or edit and source the sample_envs.sh
+  
+        `export LABKEY_VERSION="21.9.0"` ... 
+     
+        or
+     
+        `source ./sample_envs.sh`
+  1. Run the Make Build command to create the container
+
+        `make build`
+
+  1. Run the Make Up command to start the container using the makefile docker-compose settings
+
+        `make up`
+
+  1. After a few minutes LabKey should be available by opening a browser window and connecting to https://localhost:8443
+  1. Explore 
+
 ## Building a Container
 
-This repo includes a `Makefile` who's aim is to ease the running of the necessary commands for creating containers. The **default action** of the `Makefile` is to log into the AWS ECR service, build, tag, and push a docker container (the `all:` target) to an ECR repo named after the chosen distribution.
+This repo includes a `Makefile` which aim is to ease the running of the necessary commands for creating containers. The **default action** of the `Makefile` is to log into the AWS ECR service, build, tag, and push a docker container (the `all:` target) to an ECR repo named after the chosen distribution.
 
 Building a container is as simple as `make build`:
 
@@ -60,7 +83,7 @@ Successfully tagged labkey/community:21.3-snapshot
 Successfully tagged labkey/community:latest
 ```
 
-## Whats different about this Dockerfile versus others?
+## What's different about this Dockerfile versus others?
 
 This repo and Dockerfile have been built from the ground up to support LabKey products that include Spring Boot/Embedded Tomcat which can be configured using `application.properties` files. This change was made to simplify the installation of LabKey by reducing the dependencies required to get LabKey products off the ground. And to increase the configurability of LabKey products running within containers.
 
@@ -163,6 +186,9 @@ These replace values previously housed in `context.xml` (`ROOT.xml` or `labkey.x
 | SMTP_PASSWORD | SMTP password configuration | `<empty>`   |
 | SMTP_PORT     | SMTP port configuration     | `25`        |
 | SMTP_USER     | SMTP user configuration     | `root`      |
+| SMTP_FROM     | SMTP from email address     | `<empty>`   |
+| SMTP_AUTH     | SMTP Auth flag              |  `false`    |
+| SMTP_STARTTLS | SMTP STARTTLS flag          | `<empty>`   |
 
 ## SSL/Keystore/Self-signed Cert
 
@@ -201,13 +227,13 @@ In contrast to `application.properties`, the "startup properties" files housed i
 
 ## Tips
 
-You may enabled Chrome to accept self-signed certificates, such as the one generated within `entrypoint.sh`, by enabling this Chrome flag:
+You may enable Chrome to accept self-signed certificates, such as the one generated within `entrypoint.sh`, by enabling this Chrome flag:
 
 ```shell
 chrome://flags/#allow-insecure-localhost
 ```
 
-Users of Mac OS will have more luck using GNU Make as installed by **Homebrew** and executed as `gmake`.
+Users of macOS will have more luck using GNU Make as installed by **Homebrew** and executed as `gmake`.
 
 Q: Why is my labkey container "unhealthy"?
 

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ You can obtain this file by following these steps:
      
        `git clobe https://github.com/LabKey/Dockerfile.git`
   1. Copy in the labkey community embedded `.jar` file to the same directory as the repo (see above on how to obtain)
-  1. Export the minimal required environment variables or edit and source the sample_envs.sh
+  1. Export the minimal required environment variables or edit and source the quickstart_envs.sh
   
         `export LABKEY_VERSION="21.9.0"` ... 
      
         or
      
-        `source ./sample_envs.sh`
+        `source ./quickstart_envs.sh`
   1. Run the Make Build command to create the container
 
         `make build`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,8 +70,9 @@ services:
       #   '
       # - LABKEY_STARTUP_DISTRIBUTION_EXTRA=
 
-      - LABKEY_CREATE_INITIAL_USER=1
-      - LABKEY_CREATE_INITIAL_USER_APIKEY=1
+      # If these parameters are set or set to null use provided; else set values to create initial user
+      - LABKEY_CREATE_INITIAL_USER=${LABKEY_CREATE_INITIAL_USER-1}
+      - LABKEY_CREATE_INITIAL_USER_APIKEY=${LABKEY_CREATE_INITIAL_USER_APIKEY-1}
 
   postgres:
     container_name: postgres

--- a/quickstart_envs.sh
+++ b/quickstart_envs.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# example minimal set of environment variables to get started - see readme for additional envs you may wish to set
+
+# embedded tomcat LabKey .jar version to build container with
+export LABKEY_VERSION="21.9.0"
+
+# minimal SMTP settings
+export SMTP_HOST="localhost"
+export SMTP_PASSWORD=""
+export SMTP_PORT="25"
+export SMTP_USER="root"
+export SMTP_FROM="root@localhost"
+
+# Setting these two envs to empty strings defaults LabKey startup to typical first user setup wizard
+export LABKEY_CREATE_INITIAL_USER=""
+export LABKEY_CREATE_INITIAL_USER_APIKEY=""
+


### PR DESCRIPTION
- Correct a few typos
- Update docker-compose.yml to allow initial_user override vs always creating initial user
- Add TL;DR Quick start section to summarize how to get started using the repo 
- Add example quickstart_envs.sh - minimal set of envs to get started