### PR TITLE
add container name back to docker logs command for failed smoke test

### DIFF
--- a/smoke.bash
+++ b/smoke.bash
@@ -14,7 +14,7 @@ function main() {
     RETRIES=$(( RETRIES + 1 ))
 
     if [ "$RETRIES" -ge 5 ]; then
-      docker logs
+      docker logs labkey
       exit 1
     fi
 


### PR DESCRIPTION
accidentally pulled it out when cleaning up, but of course the command fails without it. Need it to diagnose failing 21.3/7/11 release builds.