### PR TITLE
Fb_devbranch_contd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ mounts/files/*
 !mounts/files/.gitkeep
 mounts/modules/*
 !mounts/modules/.gitkeep
+pgdata/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 
 services:
   labkey:
-    container_name: labkey-${DISTRO:-labkey}
+    container_name: labkey-${IDENT:-labkey}
     image: ${COMPOSE_IMAGE:-labkey/community}
     # build: {"context": ".", "args": ["LABKEY_VERSION=21.3-SNAPSHOT"]}
     # deploy:
@@ -75,7 +75,7 @@ services:
       - LABKEY_CREATE_INITIAL_USER_APIKEY=${LABKEY_CREATE_INITIAL_USER_APIKEY-1}
 
   postgres:
-    container_name: pg-${DISTRO:-labkey}
+    container_name: pg-${IDENT:-labkey}
     image: postgres:13
     # deploy:
     #   resources:
@@ -96,7 +96,7 @@ services:
       retries: 3
       start_period: 40s
     volumes:
-      - ./pgdata/${DISTRO:-postgres}-data:/var/lib/postgresql/data
+      - ./pgdata/${IDENT:-postgres}-data:/var/lib/postgresql/data
 
   # mailhog:
   #   container_name: mailhog

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 
 services:
   labkey:
-    container_name: labkey
+    container_name: labkey-${DISTRO:-labkey}
     image: ${COMPOSE_IMAGE:-labkey/community}
     # build: {"context": ".", "args": ["LABKEY_VERSION=21.3-SNAPSHOT"]}
     # deploy:
@@ -75,7 +75,7 @@ services:
       - LABKEY_CREATE_INITIAL_USER_APIKEY=${LABKEY_CREATE_INITIAL_USER_APIKEY-1}
 
   postgres:
-    container_name: postgres
+    container_name: pg-${DISTRO:-labkey}
     image: postgres:13
     # deploy:
     #   resources:
@@ -95,6 +95,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+    volumes:
+      - ./pgdata/${DISTRO:-postgres}-data:/var/lib/postgresql/data
 
   # mailhog:
   #   container_name: mailhog


### PR DESCRIPTION
IDENT is used to create a pgdata/IDENT subdir, in which the container stashes the postgres db files, for persistence. If not specified, it defaults to pgdata/postgres-data/ . 

HOST_PORT defaults to 8443, but can be changed as desired.

ex:  
[HOST_PORT=48443] \
[IDENT=community] \ 
[COMPOSE_IMAGE=labkey/community[:tag]] make up

