### PR TITLE
env vars for POSTGRES_PASSWORD and PG_PORT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ mounts/files/*
 mounts/modules/*
 !mounts/modules/.gitkeep
 pgdata/
+*.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
 
       - LOGGER_PATTERN=%-80.80logger{79}
 
-      - POSTGRES_PASSWORD=a"placeholder#'password
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-a"placeholder#'password}
       - POSTGRES_HOST=postgres
 
       - MAX_JVM_RAM_PERCENT=75.0
@@ -88,7 +88,7 @@ services:
       - "-c"
       - "docker-entrypoint.sh postgres >/dev/null 2>&1"
     environment:
-      - POSTGRES_PASSWORD=a"placeholder#'password
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-a"placeholder#'password}
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "postgres"]
       interval: 30s
@@ -97,6 +97,8 @@ services:
       start_period: 40s
     volumes:
       - ./pgdata/${IDENT:-postgres}-data:/var/lib/postgresql/data
+    ports:
+      - ${PG_PORT:-54321}:5432
 
   # mailhog:
   #   container_name: mailhog


### PR DESCRIPTION
adds POSTGRES_PASSWORD and PG_PORT as optional env vars, the latter is intentionally PG instead of POSTGRES so as not to conflict with the internal env var. PG_PORT is used to expose the pg db to the localhost. 