### PR TITLE
added distro-specific up commands to parallel runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ CACHE_FLAG ?= --no-cache
 
 TAG_LATEST ?=
 PUSH_LATEST ?=
+IDENT ?= labkey
 
 PULL_TAG ?= latest
 
@@ -89,13 +90,31 @@ push:
 
 up:
 	$(call tc,bringing up compose)
-	docker-compose up \
+	docker compose up labkey \
 		--abort-on-container-exit \
-			|| docker-compose down -v
+			|| docker compose stop labkey pg-labkey
+
+up-allpg:
+	$(call tc,bringing up compose)
+	docker compose up allpg \
+		--abort-on-container-exit \
+			|| docker compose stop allpg pg-allpg
+
+up-enterprise:
+	$(call tc,bringing up compose)
+	docker compose up enterprise \
+		--abort-on-container-exit \
+			|| docker compose stop enterprise pg-enterprise
+
+up-samplemanagement:
+	$(call tc,bringing up compose)
+	docker compose up samplemanagement \
+		--abort-on-container-exit \
+			|| docker compose stop samplemanagement pg-samplemanagement
 
 down:
 	$(call tc,tearing down compose)
-	docker-compose down -v --remove-orphans
+	docker compose down -v --remove-orphans
 
 clean:
 	docker images | grep -E '$(BUILD_REPO_NAME)|<none>' \
@@ -105,13 +124,13 @@ clean:
 
 test: down
 	$(call tc,running smoke tests)
-	docker-compose up --detach;
+	docker compose up --detach;
 	@./smoke.bash \
 		&& printf "##teamcity[progressMessage '%s']\n" 'smoke test succeeded' \
 		|| printf "##teamcity[buildProblem description='%s' identity='%s']\n" \
 			'smoke test failed' \
 			'failure'
-	docker-compose down -v
+	docker compose down -v
 
 pull: login
 	docker pull $(BUILD_REMOTE_REPO):$(PULL_TAG)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ This repo is a work in progress. Containers created from these sources are untes
 To fully use this repo, you will need installed:
 
 - Docker >= v20.10.9 recommended 
-- `docker-compose` >= v1.29.2 recommended
 - GNU Make
 - GNU Awk
 
@@ -32,7 +31,7 @@ You can obtain this file by following these steps:
      `tar -xzf [path/to/.tar.gz] --include='LabKey*labkeyServer*.jar' --strip-components 1 -C [path/to/repo/]`
 
 ## TL;DR  ... Quick Start 
-  1. brew install docker docker-compose jq awscli
+  1. brew install docker jq awscli
   1. Clone the repo to a local directory on a machine with docker installed
      
        `git clone https://github.com/LabKey/Dockerfile.git`
@@ -237,7 +236,7 @@ Users of macOS will have more luck using GNU Make as installed by **Homebrew** a
 
 Q: Why is my labkey container "unhealthy"?
 
-A: LabKey containers produced from this repo contain a [`HEALTHCHECK` instruction](https://docs.docker.com/engine/reference/builder/#healthcheck) which defines a simple "smoke" test Docker can use internally to determine if the container is healthy. The healthcheck built into this Dockerfile boils down to a `curl` to `localhost`-- but it can be customized based on a number of `HEALTHCHECK_*` ENVs that the Dockerfile defines. A customization that may be helpful would be to define a `HEALTHCHECK_HEADER_NAME` or `HEALTHCHECK_HEADER_USER_AGENT` that matches a value already filtered out of the access log by the application. Most container orchestrations tools either explicitely disable containers' built-in HEALTCHECKs or give you the option to disable able it. A succinct example of this is `docker-compose`'s own [healthcheck](https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck) syntax.
+A: LabKey containers produced from this repo contain a [`HEALTHCHECK` instruction](https://docs.docker.com/engine/reference/builder/#healthcheck) which defines a simple "smoke" test Docker can use internally to determine if the container is healthy. The healthcheck built into this Dockerfile boils down to a `curl` to `localhost`-- but it can be customized based on a number of `HEALTHCHECK_*` ENVs that the Dockerfile defines. A customization that may be helpful would be to define a `HEALTHCHECK_HEADER_NAME` or `HEALTHCHECK_HEADER_USER_AGENT` that matches a value already filtered out of the access log by the application. Most container orchestrations tools either explicitely disable containers' built-in HEALTCHECKs or give you the option to disable able it. A succinct example of this is `docker compose`'s own [healthcheck](https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck) syntax.
 
 ### Reference
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,7 @@ version: "3"
 
 services:
   labkey:
-    container_name: labkey-${IDENT:-labkey}
-    image: ${COMPOSE_IMAGE:-labkey/community}
+    image: labkey/community
     # build: {"context": ".", "args": ["LABKEY_VERSION=21.3-SNAPSHOT"]}
     # deploy:
     #   resources:
@@ -12,7 +11,7 @@ services:
     #       cpus: '0.50'
     #       memory: 1024M
     depends_on:
-      - postgres
+      - pg-labkey
       # - mailhog
     ports:
       - ${HOST_PORT:-8443}:8443
@@ -29,7 +28,7 @@ services:
       # - LABKEY_SYSTEM_DESCRIPTION=Sirius Cybernetics Corporation
 
       # - TOMCAT_ENABLE_ACCESS_LOG=1
-
+      - COMPOSE_PROJECT_NAME=labkey
       - LOG_LEVEL_SPRING_WEB=INFO
       - LOG_LEVEL_TOMCAT=DEBUG
       - LOG_LEVEL_DEFAULT=DEBUG
@@ -40,7 +39,7 @@ services:
       - LOGGER_PATTERN=%-80.80logger{79}
 
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-a"placeholder#'password}
-      - POSTGRES_HOST=postgres
+      - POSTGRES_HOST=pg-labkey
 
       - MAX_JVM_RAM_PERCENT=75.0
       - JAVA_PRE_JAR_EXTRA=-XX:+UseSerialGC -Xss512k
@@ -74,8 +73,7 @@ services:
       - LABKEY_CREATE_INITIAL_USER=${LABKEY_CREATE_INITIAL_USER-1}
       - LABKEY_CREATE_INITIAL_USER_APIKEY=${LABKEY_CREATE_INITIAL_USER_APIKEY-1}
 
-  postgres:
-    container_name: pg-${IDENT:-labkey}
+  pg-labkey:
     image: postgres:13
     # deploy:
     #   resources:
@@ -88,6 +86,106 @@ services:
       - "-c"
       - "docker-entrypoint.sh postgres >/dev/null 2>&1"
     environment:
+      - COMPOSE_PROJECT_NAME=labkey
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-a"placeholder#'password}
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    volumes:
+      - ./pgdata/postgres-data:/var/lib/postgresql/data
+    ports:
+      - ${PG_PORT:-54321}:5432
+
+
+# below are for internal LabKey testing
+  allpg:
+    image: ${COMPOSE_IMAGE:-labkey/community}
+    # build: {"context": ".", "args": ["LABKEY_VERSION=21.3-SNAPSHOT"]}
+    # deploy:
+    #   resources:
+    #     limits:
+    #       cpus: '0.50'
+    #       memory: 1024M
+    depends_on:
+      - pg-allpg
+      # - mailhog
+    ports:
+      - ${HOST_PORT:-8443}:8443
+    volumes:
+      - ./mounts/files:/labkey/files
+      # - files:/labkey/files
+      - ./mounts/modules:/labkey/externalModules
+      - ./mounts/logs:/labkey/logs
+    environment:
+      # - DEBUG=1
+
+      # - LABKEY_SYSTEM_SHORT_NAME=Sirius Cybernetics Corporation
+      # - LABKEY_COMPANY_NAME=Sirius Cybernetics Corporation
+      # - LABKEY_SYSTEM_DESCRIPTION=Sirius Cybernetics Corporation
+
+      # - TOMCAT_ENABLE_ACCESS_LOG=1
+      - COMPOSE_PROJECT_NAME=allpg
+      - LOG_LEVEL_SPRING_WEB=INFO
+      - LOG_LEVEL_TOMCAT=DEBUG
+      - LOG_LEVEL_DEFAULT=DEBUG
+      - LOG_LEVEL_LABKEY_DEFAULT=DEBUG
+      - LOG_LEVEL_API_SETTINGS=DEBUG
+      - LOG_LEVEL_API_MODULELOADER=DEBUG
+
+      - LOGGER_PATTERN=%-80.80logger{79}
+
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-a"placeholder#'password}
+      - POSTGRES_HOST=pg-allpg
+
+      - MAX_JVM_RAM_PERCENT=75.0
+      - JAVA_PRE_JAR_EXTRA=-XX:+UseSerialGC -Xss512k
+
+      # - SMTP_HOST=mailhog
+      # - SMTP_PORT=1025
+
+      - SMTP_HOST=${SMTP_HOST}
+      - SMTP_AUTH=true
+      - SMTP_PORT=587
+      - SMTP_USER=${SMTP_USER}
+      - SMTP_PASSWORD=${SMTP_PASSWORD}
+      - SMTP_STARTTLS=true
+
+      - LABKEY_SYSTEM_EMAIL_ADDRESS=${SMTP_FROM}
+      # - SMTP_FROM=
+
+      # uncomment to enable CAS against labkey.org
+      # - |
+      #   LABKEY_STARTUP_BASIC_EXTRA='
+      #     CasAuthenticationProperties.ServerURL;startup = https://www.labkey.org/cas
+      #     CasAuthenticationProperties.AutoRedirect;startup = true
+      #     CasAuthenticationProperties.InvokeLogout;startup = true
+      #     CasAuthenticationProperties.Description;startup = configured_by_docker_compose
+      #     SiteSettings.experimentalFeature.disableGuestAccount = TRUE
+      #     UserRoles.${LABKEY_ACCOUNT_EMAIL} = org.labkey.api.security.roles.SiteAdminRole
+      #   '
+      # - LABKEY_STARTUP_DISTRIBUTION_EXTRA=
+
+      # If these parameters are set or set to null use provided; else set values to create initial user
+      - LABKEY_CREATE_INITIAL_USER=${LABKEY_CREATE_INITIAL_USER-1}
+      - LABKEY_CREATE_INITIAL_USER_APIKEY=${LABKEY_CREATE_INITIAL_USER_APIKEY-1}
+
+  pg-allpg:
+    image: postgres:13
+    # deploy:
+    #   resources:
+    #     limits:
+    #       cpus: '0.25'
+    #       memory: 512M
+    # silent postgres w/o needing to remake the container!
+    entrypoint:
+      - "/bin/bash"
+      - "-c"
+      - "docker-entrypoint.sh postgres >/dev/null 2>&1"
+    environment:
+      - COMPOSE_PROJECT_NAME=allpg
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-a"placeholder#'password}
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "postgres"]
@@ -99,6 +197,203 @@ services:
       - ./pgdata/${IDENT:-postgres}-data:/var/lib/postgresql/data
     ports:
       - ${PG_PORT:-54321}:5432
+
+  enterprise:
+    image: ${COMPOSE_IMAGE:-labkey/community}
+    # build: {"context": ".", "args": ["LABKEY_VERSION=21.3-SNAPSHOT"]}
+    # deploy:
+    #   resources:
+    #     limits:
+    #       cpus: '0.50'
+    #       memory: 1024M
+    depends_on:
+      - pg-enterprise
+      # - mailhog
+    ports:
+      - ${HOST_PORT:-8443}:8443
+    volumes:
+      - ./mounts/files:/labkey/files
+      # - files:/labkey/files
+      - ./mounts/modules:/labkey/externalModules
+      - ./mounts/logs:/labkey/logs
+    environment:
+      # - DEBUG=1
+
+      # - LABKEY_SYSTEM_SHORT_NAME=Sirius Cybernetics Corporation
+      # - LABKEY_COMPANY_NAME=Sirius Cybernetics Corporation
+      # - LABKEY_SYSTEM_DESCRIPTION=Sirius Cybernetics Corporation
+
+      # - TOMCAT_ENABLE_ACCESS_LOG=1
+      - COMPOSE_PROJECT_NAME=enterprise
+      - LOG_LEVEL_SPRING_WEB=INFO
+      - LOG_LEVEL_TOMCAT=DEBUG
+      - LOG_LEVEL_DEFAULT=DEBUG
+      - LOG_LEVEL_LABKEY_DEFAULT=DEBUG
+      - LOG_LEVEL_API_SETTINGS=DEBUG
+      - LOG_LEVEL_API_MODULELOADER=DEBUG
+
+      - LOGGER_PATTERN=%-80.80logger{79}
+
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-a"placeholder#'password}
+      - POSTGRES_HOST=pg-enterprise
+
+      - MAX_JVM_RAM_PERCENT=75.0
+      - JAVA_PRE_JAR_EXTRA=-XX:+UseSerialGC -Xss512k
+
+      # - SMTP_HOST=mailhog
+      # - SMTP_PORT=1025
+
+      - SMTP_HOST=${SMTP_HOST}
+      - SMTP_AUTH=true
+      - SMTP_PORT=587
+      - SMTP_USER=${SMTP_USER}
+      - SMTP_PASSWORD=${SMTP_PASSWORD}
+      - SMTP_STARTTLS=true
+
+      - LABKEY_SYSTEM_EMAIL_ADDRESS=${SMTP_FROM}
+      # - SMTP_FROM=
+
+      # uncomment to enable CAS against labkey.org
+      # - |
+      #   LABKEY_STARTUP_BASIC_EXTRA='
+      #     CasAuthenticationProperties.ServerURL;startup = https://www.labkey.org/cas
+      #     CasAuthenticationProperties.AutoRedirect;startup = true
+      #     CasAuthenticationProperties.InvokeLogout;startup = true
+      #     CasAuthenticationProperties.Description;startup = configured_by_docker_compose
+      #     SiteSettings.experimentalFeature.disableGuestAccount = TRUE
+      #     UserRoles.${LABKEY_ACCOUNT_EMAIL} = org.labkey.api.security.roles.SiteAdminRole
+      #   '
+      # - LABKEY_STARTUP_DISTRIBUTION_EXTRA=
+
+      # If these parameters are set or set to null use provided; else set values to create initial user
+      - LABKEY_CREATE_INITIAL_USER=${LABKEY_CREATE_INITIAL_USER-1}
+      - LABKEY_CREATE_INITIAL_USER_APIKEY=${LABKEY_CREATE_INITIAL_USER_APIKEY-1}
+
+  pg-enterprise:
+    image: postgres:13
+    # deploy:
+    #   resources:
+    #     limits:
+    #       cpus: '0.25'
+    #       memory: 512M
+    # silent postgres w/o needing to remake the container!
+    entrypoint:
+      - "/bin/bash"
+      - "-c"
+      - "docker-entrypoint.sh postgres >/dev/null 2>&1"
+    environment:
+      - COMPOSE_PROJECT_NAME=enterprise
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-a"placeholder#'password}
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    volumes:
+      - ./pgdata/${IDENT:-postgres}-data:/var/lib/postgresql/data
+    ports:
+      - ${PG_PORT:-54321}:5432
+
+  samplemanagement:
+    image: ${COMPOSE_IMAGE:-labkey/community}
+    # build: {"context": ".", "args": ["LABKEY_VERSION=21.3-SNAPSHOT"]}
+    # deploy:
+    #   resources:
+    #     limits:
+    #       cpus: '0.50'
+    #       memory: 1024M
+    depends_on:
+      - pg-samplemanagement
+      # - mailhog
+    ports:
+      - ${HOST_PORT:-8443}:8443
+    volumes:
+      - ./mounts/files:/labkey/files
+      # - files:/labkey/files
+      - ./mounts/modules:/labkey/externalModules
+      - ./mounts/logs:/labkey/logs
+    environment:
+      # - DEBUG=1
+
+      # - LABKEY_SYSTEM_SHORT_NAME=Sirius Cybernetics Corporation
+      # - LABKEY_COMPANY_NAME=Sirius Cybernetics Corporation
+      # - LABKEY_SYSTEM_DESCRIPTION=Sirius Cybernetics Corporation
+
+      # - TOMCAT_ENABLE_ACCESS_LOG=1
+      - COMPOSE_PROJECT_NAME=samplemanagement
+      - LOG_LEVEL_SPRING_WEB=INFO
+      - LOG_LEVEL_TOMCAT=DEBUG
+      - LOG_LEVEL_DEFAULT=DEBUG
+      - LOG_LEVEL_LABKEY_DEFAULT=DEBUG
+      - LOG_LEVEL_API_SETTINGS=DEBUG
+      - LOG_LEVEL_API_MODULELOADER=DEBUG
+
+      - LOGGER_PATTERN=%-80.80logger{79}
+
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-a"placeholder#'password}
+      - POSTGRES_HOST=pg-samplemanagement
+
+      - MAX_JVM_RAM_PERCENT=75.0
+      - JAVA_PRE_JAR_EXTRA=-XX:+UseSerialGC -Xss512k
+
+      # - SMTP_HOST=mailhog
+      # - SMTP_PORT=1025
+
+      - SMTP_HOST=${SMTP_HOST}
+      - SMTP_AUTH=true
+      - SMTP_PORT=587
+      - SMTP_USER=${SMTP_USER}
+      - SMTP_PASSWORD=${SMTP_PASSWORD}
+      - SMTP_STARTTLS=true
+
+      - LABKEY_SYSTEM_EMAIL_ADDRESS=${SMTP_FROM}
+      # - SMTP_FROM=
+
+      # uncomment to enable CAS against labkey.org
+      # - |
+      #   LABKEY_STARTUP_BASIC_EXTRA='
+      #     CasAuthenticationProperties.ServerURL;startup = https://www.labkey.org/cas
+      #     CasAuthenticationProperties.AutoRedirect;startup = true
+      #     CasAuthenticationProperties.InvokeLogout;startup = true
+      #     CasAuthenticationProperties.Description;startup = configured_by_docker_compose
+      #     SiteSettings.experimentalFeature.disableGuestAccount = TRUE
+      #     UserRoles.${LABKEY_ACCOUNT_EMAIL} = org.labkey.api.security.roles.SiteAdminRole
+      #   '
+      # - LABKEY_STARTUP_DISTRIBUTION_EXTRA=
+
+      # If these parameters are set or set to null use provided; else set values to create initial user
+      - LABKEY_CREATE_INITIAL_USER=${LABKEY_CREATE_INITIAL_USER-1}
+      - LABKEY_CREATE_INITIAL_USER_APIKEY=${LABKEY_CREATE_INITIAL_USER_APIKEY-1}
+
+  pg-samplemanagement:
+    image: postgres:13
+    # deploy:
+    #   resources:
+    #     limits:
+    #       cpus: '0.25'
+    #       memory: 512M
+    # silent postgres w/o needing to remake the container!
+    entrypoint:
+      - "/bin/bash"
+      - "-c"
+      - "docker-entrypoint.sh postgres >/dev/null 2>&1"
+    environment:
+      - COMPOSE_PROJECT_NAME=samplemanagement
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-a"placeholder#'password}
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    volumes:
+      - ./pgdata/${IDENT:-postgres}-data:/var/lib/postgresql/data
+    ports:
+      - ${PG_PORT:-54321}:5432
+
+
+# below can optionally be added to services above as needed
 
   # mailhog:
   #   container_name: mailhog

--- a/quickstart_envs.sh
+++ b/quickstart_envs.sh
@@ -3,7 +3,7 @@
 # example minimal set of environment variables to get started - see readme for additional envs you may wish to set
 
 # embedded tomcat LabKey .jar version to build container with
-export LABKEY_VERSION="22.3.0"
+export LABKEY_VERSION="22.3.4"
 
 # minimal SMTP settings
 export SMTP_HOST="localhost"


### PR DESCRIPTION
'make up' works as before for community users, but there's now also 'make up-allpg', 'make up-enterprise', and 'make up-samplemanagement', for internal testing of the different distros at the same time.

also changed 'docker-compose' to 'docker compose' , using the newer embedded version in docker itself.