### PR TITLE
fix intermittent build failures due to "can't stat '/mnt/...' "

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ mounts/modules/*
 !mounts/modules/.gitkeep
 pgdata/
 *.sql
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -120,14 +120,13 @@ clean:
 
 test: down
 	$(call tc,running smoke tests)
-	docker-compose up --detach ${BUILD_DISTRIBUTION};
+	IDENT=${BUILD_DISTRIBUTION} docker-compose up --detach ${BUILD_DISTRIBUTION};
 	@./smoke.bash \
 		&& printf "##teamcity[progressMessage '%s']\n" 'smoke test succeeded' \
 		|| printf "##teamcity[buildProblem description='%s' identity='%s']\n" \
 			'smoke test failed' \
 			'failure'
-	docker-compose down -v
-	rm -rf pgdata
+	IDENT=${BUILD_DISTRIBUTION} docker-compose down -v
 
 pull: login
 	docker pull $(BUILD_REMOTE_REPO):$(PULL_TAG)

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,8 @@ clean:
 	docker images | grep -E '$(BUILD_REPO_NAME)|<none>' \
 		| awk '{print $$3}' | sort -u | $(_G)xargs -r docker image rm -f \
 			&& $(_G)find mounts/logs/ -name '*.log' -type f -print0 \
-				| $(_G)xargs -r -0 -t truncate -s0;
+				| $(_G)xargs -r -0 -t truncate -s0 \
+			&& rm -rf pgdata;
 
 test: down
 	$(call tc,running smoke tests)

--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,7 @@ clean:
 	docker images | grep -E '$(BUILD_REPO_NAME)|<none>' \
 		| awk '{print $$3}' | sort -u | $(_G)xargs -r docker image rm -f \
 			&& $(_G)find mounts/logs/ -name '*.log' -type f -print0 \
-				| $(_G)xargs -r -0 -t truncate -s0 \
-			&& rm -rf pgdata;
+				| $(_G)xargs -r -0 -t truncate -s0;
 
 test: down
 	$(call tc,running smoke tests)
@@ -128,6 +127,7 @@ test: down
 			'smoke test failed' \
 			'failure'
 	docker-compose down -v
+	rm -rf pgdata
 
 pull: login
 	docker pull $(BUILD_REMOTE_REPO):$(PULL_TAG)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ version: "3"
 services:
   community:
     image: labkey/community
+    container_name: ${IDENT:-labkey}
     # build: {"context": ".", "args": ["LABKEY_VERSION=21.3-SNAPSHOT"]}
     # deploy:
     #   resources:
@@ -101,6 +102,7 @@ services:
 # below are for internal LabKey testing
   allpg:
     image: ${COMPOSE_IMAGE:-labkey/community}
+    container_name: ${IDENT:-allpg}
     # build: {"context": ".", "args": ["LABKEY_VERSION=21.3-SNAPSHOT"]}
     # deploy:
     #   resources:
@@ -196,6 +198,7 @@ services:
 
   enterprise:
     image: ${COMPOSE_IMAGE:-labkey/community}
+    container_name: ${IDENT:-enterprise}
     # build: {"context": ".", "args": ["LABKEY_VERSION=21.3-SNAPSHOT"]}
     # deploy:
     #   resources:
@@ -291,6 +294,7 @@ services:
 
   samplemanagement:
     image: ${COMPOSE_IMAGE:-labkey/community}
+    container_name: ${IDENT:-samplemanagement}
     # build: {"context": ".", "args": ["LABKEY_VERSION=21.3-SNAPSHOT"]}
     # deploy:
     #   resources:

--- a/smoke.bash
+++ b/smoke.bash
@@ -14,7 +14,7 @@ function main() {
     RETRIES=$(( RETRIES + 1 ))
 
     if [ "$RETRIES" -ge 5 ]; then
-      docker logs labkey
+      docker logs ${BUILD_DISTRIBUTION:-labkey}
       exit 1
     fi
 


### PR DESCRIPTION
the intermittent failure of "can't stat '/mnt/teamcity/work/652f1c2726604b2f/pgdata/labkey-data" (example [here](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Internal_Embedded_SampleManagerContainer/1915841?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildProblemsSection=true) )

... was caused by the 'make test' commands missing the IDENT variable. This meant that all 3 distros (allpg, samplemanagement, enterprise) used the same mount path for their pgdata. If then 2 different distros ran on the same spot host, the 2nd job would not be able to clean up or use the leftover directory from the 1st job. This fixes the build so that each job gets their own, matching mount path.

This PR also adds 'container_name' to the docker-compose.yml, and a matching bit to the smoke test script, so that the 'docker logs' command will actually work when the smoke tests fail.