### PR TITLE
add hadolint github action

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,0 +1,22 @@
+name: hadolint
+
+on:
+  push:
+    branches:
+      - fb_*
+
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  hadolint:
+    name: hadolint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Run hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile


### PR DESCRIPTION
simply runs hadolint, and fails the push/PR if errors are found.