### PR TITLE
Add missing database context properties

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -79,6 +79,11 @@ context.driverClassName[0]=org.postgresql.Driver
 context.url[0]=jdbc:postgresql://${POSTGRES_HOST:-localhost}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-${POSTGRES_USER}}${POSTGRES_PARAMETERS:-}
 context.username[0]=${POSTGRES_USER:-postgres}
 context.password[0]=${POSTGRES_PASSWORD:-}
+context.maxTotal[0]=50
+context.maxIdle[0]=10
+context.maxWaitMillis[0]=120000
+context.accessToUnderlyingConnectionAllowed[0]=true
+context.validationQuery[0]=SELECT 1
 
 # context.dataSourceName[1]=jdbc/@@extraJdbcDataSource@@
 # context.driverClassName[1]=@@extraJdbcDriverClassName@@


### PR DESCRIPTION
Started seeing NPEs on TeamCity after some [new properties were added](https://github.com/LabKey/server/pull/529) for embedded tomcat:
```
java.lang.NullPointerException: Cannot invoke "java.util.List.get(int)" because the return value of "org.labkey.embedded.LabKeyServer$ContextProperties.getMaxTotal()" is null
     at org.labkey.embedded.LabKeyServer$1.getDataSourceResources(LabKeyServer.java:163) ~[classes!/:na]
     at org.labkey.embedded.LabKeyServer$1.getTomcatWebServer(LabKeyServer.java:111) ~[classes!/:na]
     at org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory.getWebServer(TomcatServletWebServerFactory.java:211) ~[spring-boot-2.7.13.jar!/:2.7.13]
     at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.createWebServer(ServletWebServerApplicationContext.java:184) ~[spring-boot-2.7.13.jar!/:2.7.13]
     at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.onRefresh(ServletWebServerApplicationContext.java:162) ~[spring-boot-2.7.13.jar!/:2.7.13]
```
Just hard-coding the default values for now to get TeamCity running smoothly.