### PR TITLE
set LKMS startup properties to correct paths

### DIFF
--- a/startup/lims_starter.properties
+++ b/startup/lims_starter.properties
@@ -1,8 +1,8 @@
 FolderTypes.disabledTypes=Dataspace
 
-LookAndFeelSettings.customStylesheet=lims_starter:data/files/customStylesheet.css
-LookAndFeelSettings.iconImage=lims_starter:data/files/iconImage.ico
-LookAndFeelSettings.logoImage=lims_starter:data/files/logoImage.svg
+LookAndFeelSettings.customStylesheet=sampleManagement:data/files/customStylesheet.css
+LookAndFeelSettings.iconImage=sampleManagement:data/files/iconImage.ico
+LookAndFeelSettings.logoImage=sampleManagement:data/files/logoImage.svg
 LookAndFeelSettings.themeName=Sky
 
 SampleManager.updateSecurityEmailTemplates=true


### PR DESCRIPTION
Update default lims_starter startup properties to use correct paths for the samplemanagement module.  

It appears these were mistakenly changed when the samplemanagement distribution was retired.  These startup properties use paths to where the files reside and not the distribution name. 