### PR TITLE
security improvements: purge secrets from env vars; rm awscli after s3 cp completes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -198,12 +198,13 @@ COPY "startup/${LABKEY_DISTRIBUTION}.properties" \
 # add logging config files
 COPY log4j2.xml log4j2.xml
 
-# add aws cli
-RUN mkdir -p /usr/src/awsclizip \
+# add aws cli & make it owned by labkey user so it can all be deleted after s3 downloads in entrypoint.sh
+RUN mkdir -p /usr/src/awsclizip "${LABKEY_HOME}/awsclibin" "${LABKEY_HOME}/aws-cli" \
     && wget -q -O /usr/src/awsclizip/awscliv2.zip "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" \
     && unzip -q -d /usr/src/awsclizip/ /usr/src/awsclizip/awscliv2.zip \
-    && /usr/src/awsclizip/aws/install \
-    && rm -rf /usr/src/awsclizip
+    && /usr/src/awsclizip/aws/install --bin-dir "${LABKEY_HOME}/awsclibin" --install-dir "${LABKEY_HOME}/aws-cli" \
+    && rm -rf /usr/src/awsclizip \
+    && chown -R labkey:labkey "${LABKEY_HOME}/awsclibin" "${LABKEY_HOME}/aws-cli"
 
 # refrain from using shell significant characters in HEALTHCHECK_HEADER_*
 ENV HEALTHCHECK_INTERVAL="6s" \

--- a/application.properties
+++ b/application.properties
@@ -76,9 +76,13 @@ logging.level.org.apache.tomcat.util.digester.Digester=INFO
 
 context.dataSourceName[0]=jdbc/labkeyDataSource
 context.driverClassName[0]=org.postgresql.Driver
-context.url[0]=jdbc:postgresql://${POSTGRES_HOST:-localhost}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-${POSTGRES_USER}}${POSTGRES_PARAMETERS:-}
-context.username[0]=${POSTGRES_USER:-postgres}
-context.password[0]=${POSTGRES_PASSWORD:-}
+# context.url[0]=jdbc:postgresql://${POSTGRES_HOST:-localhost}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-${POSTGRES_USER}}${POSTGRES_PARAMETERS:-}
+# context.username[0]=${POSTGRES_USER:-postgres}
+# context.password[0]=${POSTGRES_PASSWORD:-}
+
+context.url[0]=@@jdbcUrl@@
+context.username[0]=@@jdbcUser@@
+context.password[0]=@@jdbcPassword@@
 
 # the ':-' setup doesn't appeear to work. They have to be set as env vars anyway, but at least this shows the indended defaults set elsewhere
 context.maxTotal[0]=${POSTGRES_MAX_TOTAL_CONNECTIONS:-50}
@@ -123,7 +127,7 @@ server.ssl.key-store=${LABKEY_HOME}/${TOMCAT_KEYSTORE_FILENAME:-labkey.p12}
 # server.ssl.key-store-password=${TOMCAT_KEYSTORE_PASSWORD}
 server.ssl.key-store-type=${TOMCAT_KEYSTORE_FORMAT:-PKCS12}
 
-context.encryptionKey=${LABKEY_EK}
+context.encryptionKey=@@encryptionKey@@
 context.serverGUID=${LABKEY_GUID}
 
 #
@@ -134,13 +138,13 @@ server.servlet.context-path=/_
 
 server.error.whitelabel.enabled=false
 
-mail.smtpHost=${SMTP_HOST}
-mail.smtpUser=${SMTP_USER}
-mail.smtpPort=${SMTP_PORT}
-mail.smtpPassword=${SMTP_PASSWORD}
-mail.smtpAuth=${SMTP_AUTH}
-mail.smtpFrom=${SMTP_FROM}
-mail.smtpStartTlsEnable=${SMTP_STARTTLS}
+mail.smtpHost=@@smtpHost@@
+mail.smtpUser=@@smtpUser@@
+mail.smtpPort==@@smtpPort@@
+mail.smtpPassword==@@@@
+mail.smtpAuth==@@smtpPassword@@
+mail.smtpFrom==@@smtpFrom@@
+mail.smtpStartTlsEnable==@@smtpStartTlsEnable@@
 
 management.endpoints.web.base-path=/
 

--- a/quickstart_envs.sh
+++ b/quickstart_envs.sh
@@ -3,7 +3,7 @@
 # example minimal set of environment variables to get started - see readme for additional envs you may wish to set
 
 # embedded tomcat LabKey .jar version to build container with
-export LABKEY_VERSION="23.8-SNAPSHOT"
+export LABKEY_VERSION="23.8"
 
 # minimal SMTP settings
 export SMTP_HOST="localhost"

--- a/quickstart_envs.sh
+++ b/quickstart_envs.sh
@@ -3,7 +3,7 @@
 # example minimal set of environment variables to get started - see readme for additional envs you may wish to set
 
 # embedded tomcat LabKey .jar version to build container with
-export LABKEY_VERSION="23.8"
+export LABKEY_VERSION="23.8-SNAPSHOT"
 
 # minimal SMTP settings
 export SMTP_HOST="localhost"


### PR DESCRIPTION
Instead of keeping the secrets in env vars (from which they're displayed in the running server's env vars admin page), this writes them to the application.properties file, which the server reads during startup, then unsets the env vars.

This change also deletes the aws cli from the container's filesystem after the optional download of startup properties from s3.

test run: https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Internal_Embedded_LimsStarterContainer/2570285?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true