### PR TITLE
add de-fang command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -246,6 +246,9 @@ EXPOSE ${LABKEY_PORT}
 
 STOPSIGNAL SIGTERM
 
+# defang
+RUN find / -xdev -perm /6000 -type f -exec chmod a-s {} \; || true
+
 USER labkey
 
 # shell form e.g. executed w/ /bin/sh -c


### PR DESCRIPTION
This doesn't seem to have any effect on our current setup, so I suspect the eclipse-temurin image is already 'defanged' in this way, but its good to have it explicitly here just in case.

https://aws.github.io/aws-eks-best-practices/security/docs/image/#create-minimal-images
