### PR TITLE
remove newinstall flag and be deliberate about startup properties by …

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -169,7 +169,8 @@ main() {
       -passout "pass:${keystore_pass}" \
         >/dev/null 2>&1
 
-  touch server/startup/newinstall
+  # Removed as this setting results in every startup being interrupted as a boostrap
+  #touch server/startup/newinstall
 
   if [ -n "${DEBUG:-}" ]; then
     tail -n+1 \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -169,9 +169,6 @@ main() {
       -passout "pass:${keystore_pass}" \
         >/dev/null 2>&1
 
-  # Removed as this setting results in every startup being interrupted as a boostrap
-  #touch server/startup/newinstall
-
   if [ -n "${DEBUG:-}" ]; then
     tail -n+1 \
       config/*.properties \

--- a/startup/basic.properties
+++ b/startup/basic.properties
@@ -12,7 +12,7 @@ SiteSettings.baseServerURL;bootstrap=${LABKEY_BASE_SERVER_URL}
 Authentication.DefaultDomain;bootstrap=${LABKEY_DEFAULT_DOMAIN}
 SiteSettings.pipelineToolsDirectory;bootstrap=${LABKEY_HOME}
 
-SiteSettings.sslPort=${LABKEY_PORT}
-SiteSettings.sslRequired=true
+SiteSettings.sslPort;startup=${LABKEY_PORT}
+SiteSettings.sslRequired;startup=true
 
 ${LABKEY_STARTUP_BASIC_EXTRA}

--- a/startup/lims_starter.properties
+++ b/startup/lims_starter.properties
@@ -1,14 +1,14 @@
-FolderTypes.disabledTypes=Dataspace
+FolderTypes.disabledTypes;bootstrap=Dataspace
 
-LookAndFeelSettings.customStylesheet=sampleManagement:data/files/customStylesheet.css
-LookAndFeelSettings.iconImage=sampleManagement:data/files/iconImage.ico
-LookAndFeelSettings.logoImage=sampleManagement:data/files/logoImage.svg
-LookAndFeelSettings.themeName=Sky
+LookAndFeelSettings.customStylesheet;bootstrap=sampleManagement:data/files/customStylesheet.css
+LookAndFeelSettings.iconImage;bootstrap=sampleManagement:data/files/iconImage.ico
+LookAndFeelSettings.logoImage;bootstrap=sampleManagement:data/files/logoImage.svg
+LookAndFeelSettings.themeName;bootstrap=Sky
 
-SampleManager.updateSecurityEmailTemplates=true
+SampleManager.updateSecurityEmailTemplates;bootstrap=true
 
-SiteSettings.homeProjectFolderType=Sample Manager
-SiteSettings.homeProjectResetPermissions=true
+SiteSettings.homeProjectFolderType;bootstrap=Sample Manager
+SiteSettings.homeProjectResetPermissions;bootstrap=true
 
 # LKSM Pro
 ModuleLoader.exclude=biologics


### PR DESCRIPTION
…specifying startup type

* Removes newinstall flag which was resulting in every container start = bootstrap
* Update startup properties to be deliberate about specifying which type the property should be used for.  (e..g. startup or bootstrap) 