### PR TITLE
set default bootstrap DatabaseAuthentication.Strength to good

### DIFF
--- a/startup/basic.properties
+++ b/startup/basic.properties
@@ -15,4 +15,7 @@ SiteSettings.pipelineToolsDirectory;bootstrap=${LABKEY_HOME}
 SiteSettings.sslPort;startup=${LABKEY_PORT}
 SiteSettings.sslRequired;startup=true
 
+# TODO remove with 23.11
+DatabaseAuthentication.Strength;bootstrap = Good
+
 ${LABKEY_STARTUP_BASIC_EXTRA}


### PR DESCRIPTION
Sets default bootstrap Database Authentication strength to "Good" which is the old "strong" for new container deployments with 23.10+

- Required during transition period so that new deployments get the minimum of the old strong policy so we can later upgrade to the new strong policy in 23.11.x when we have the UI to help users. 