### PR TITLE
add workDir context and session timeout

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -161,3 +161,5 @@ info.labkey.version=${LABKEY_VERSION}
 info.labkey.distribution=${LABKEY_DISTRIBUTION}
 
 server.tomcat.max-threads=50
+server.servlet.session.timeout=60m
+context.workDirLocation=/tmp/workDir


### PR DESCRIPTION
Adds application.properties values for:
* context.workDirLocation=
* server.servlet.session.timeout

The workDir value coincides with https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=48426