### PR TITLE
fix for tomcat workDir on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -175,9 +175,11 @@ RUN [ -n "${DEBUG}" ] && set -x; \
         "logs" \
         "server/startup" \
         "${TOMCAT_BASE_DIR}" \
+        "/work/Tomcat/localhost" \
     \
     && env | sort | tee /buid.env; \
     \
+    chown -Rc labkey:labkey "/work/Tomcat/localhost"; \
     chown -Rc labkey:labkey "${LABKEY_HOME}";
 
 

--- a/application.properties
+++ b/application.properties
@@ -162,4 +162,4 @@ info.labkey.distribution=${LABKEY_DISTRIBUTION}
 
 server.tomcat.max-threads=50
 server.servlet.session.timeout=60m
-context.workDirLocation=/tmp/workDir
+context.workDirLocation=/work/Tomcat/localhost


### PR DESCRIPTION
Addresses issue with errors at startup about Tomcat Work directory
 
Related to issue: https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=48426