### PR TITLE
add heapdump path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -170,6 +170,7 @@ RUN [ -n "${DEBUG}" ] && set -x; \
     \
     mkdir -pv \
         "${LABKEY_FILES_ROOT}/@files" \
+        "${LABKEY_FILES_ROOT}/tomcat-tmp" \
         "config" \
         "externalModules" \
         "logs" \
@@ -244,6 +245,7 @@ HEALTHCHECK \
             || exit 1
 
 VOLUME "${LABKEY_FILES_ROOT}/@files"
+VOLUME "${LABKEY_FILES_ROOT}/tomcat-tmp"
 VOLUME "${LABKEY_HOME}/externalModules"
 VOLUME "${LABKEY_HOME}/logs"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -170,7 +170,6 @@ RUN [ -n "${DEBUG}" ] && set -x; \
     \
     mkdir -pv \
         "${LABKEY_FILES_ROOT}/@files" \
-        "${LABKEY_FILES_ROOT}/tomcat-tmp" \
         "config" \
         "externalModules" \
         "logs" \
@@ -245,7 +244,6 @@ HEALTHCHECK \
             || exit 1
 
 VOLUME "${LABKEY_FILES_ROOT}/@files"
-VOLUME "${LABKEY_FILES_ROOT}/tomcat-tmp"
 VOLUME "${LABKEY_HOME}/externalModules"
 VOLUME "${LABKEY_HOME}/logs"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
       - ${HOST_PORT:-8443}:8443
     volumes:
       - ./mounts/files:/labkey/files
-      # - ./mounts/files/tomcat-tmp:/labkey/files/tomcat-tmp
       # - files:/labkey/files
       - ./mounts/modules:/labkey/externalModules
       - ./mounts/logs:/labkey/logs
@@ -130,7 +129,6 @@ services:
       - ${HOST_PORT:-8443}:8443
     volumes:
       - ./mounts/files:/labkey/files
-      # - ./mounts/files/tomcat-tmp:/labkey/files/tomcat-tmp
       # - files:/labkey/files
       - ./mounts/modules:/labkey/externalModules
       - ./mounts/logs:/labkey/logs
@@ -240,7 +238,6 @@ services:
       - ${HOST_PORT:-8443}:8443
     volumes:
       - ./mounts/files:/labkey/files
-      # - ./mounts/files/tomcat-tmp:/labkey/files/tomcat-tmp
       # - files:/labkey/files
       - ./mounts/modules:/labkey/externalModules
       - ./mounts/logs:/labkey/logs
@@ -350,7 +347,6 @@ services:
       - ${HOST_PORT:-8443}:8443
     volumes:
       - ./mounts/files:/labkey/files
-      # - ./mounts/files/tomcat-tmp:/labkey/files/tomcat-tmp
       # - files:/labkey/files
       - ./mounts/modules:/labkey/externalModules
       - ./mounts/logs:/labkey/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - ${HOST_PORT:-8443}:8443
     volumes:
       - ./mounts/files:/labkey/files
+      - ./mounts/files/tomcat-tmp:/labkey/files/tomcat-tmp
       # - files:/labkey/files
       - ./mounts/modules:/labkey/externalModules
       - ./mounts/logs:/labkey/logs
@@ -41,7 +42,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-a"placeholder#'password}
       - POSTGRES_HOST=pg-community
 
-      - MAX_JVM_RAM_PERCENT=75.0
+      - MAX_JVM_RAM_PERCENT=${MAX_JVM_RAM_PERCENT:-75.0}
       - JAVA_PRE_JAR_EXTRA=-XX:+UseSerialGC -Xss512k
 
       # - SMTP_HOST=mailhog
@@ -129,6 +130,7 @@ services:
       - ${HOST_PORT:-8443}:8443
     volumes:
       - ./mounts/files:/labkey/files
+      - ./mounts/files/tomcat-tmp:/labkey/files/tomcat-tmp
       # - files:/labkey/files
       - ./mounts/modules:/labkey/externalModules
       - ./mounts/logs:/labkey/logs
@@ -152,7 +154,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-a"placeholder#'password}
       - POSTGRES_HOST=pg-allpg
 
-      - MAX_JVM_RAM_PERCENT=75.0
+      - MAX_JVM_RAM_PERCENT=${MAX_JVM_RAM_PERCENT:-75.0}
       - JAVA_PRE_JAR_EXTRA=-XX:+UseSerialGC -Xss512k
 
       # - SMTP_HOST=mailhog
@@ -238,6 +240,7 @@ services:
       - ${HOST_PORT:-8443}:8443
     volumes:
       - ./mounts/files:/labkey/files
+      - ./mounts/files/tomcat-tmp:/labkey/files/tomcat-tmp
       # - files:/labkey/files
       - ./mounts/modules:/labkey/externalModules
       - ./mounts/logs:/labkey/logs
@@ -261,7 +264,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-a"placeholder#'password}
       - POSTGRES_HOST=pg-enterprise
 
-      - MAX_JVM_RAM_PERCENT=75.0
+      - MAX_JVM_RAM_PERCENT=${MAX_JVM_RAM_PERCENT:-75.0}
       - JAVA_PRE_JAR_EXTRA=-XX:+UseSerialGC -Xss512k
 
       # - SMTP_HOST=mailhog
@@ -347,6 +350,7 @@ services:
       - ${HOST_PORT:-8443}:8443
     volumes:
       - ./mounts/files:/labkey/files
+      - ./mounts/files/tomcat-tmp:/labkey/files/tomcat-tmp
       # - files:/labkey/files
       - ./mounts/modules:/labkey/externalModules
       - ./mounts/logs:/labkey/logs
@@ -370,7 +374,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-a"placeholder#'password}
       - POSTGRES_HOST=pg-lims_starter
 
-      - MAX_JVM_RAM_PERCENT=75.0
+      - MAX_JVM_RAM_PERCENT=${MAX_JVM_RAM_PERCENT:-75.0}
       - JAVA_PRE_JAR_EXTRA=-XX:+UseSerialGC -Xss512k
 
       # - SMTP_HOST=mailhog

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - ${HOST_PORT:-8443}:8443
     volumes:
       - ./mounts/files:/labkey/files
-      - ./mounts/files/tomcat-tmp:/labkey/files/tomcat-tmp
+      # - ./mounts/files/tomcat-tmp:/labkey/files/tomcat-tmp
       # - files:/labkey/files
       - ./mounts/modules:/labkey/externalModules
       - ./mounts/logs:/labkey/logs
@@ -130,7 +130,7 @@ services:
       - ${HOST_PORT:-8443}:8443
     volumes:
       - ./mounts/files:/labkey/files
-      - ./mounts/files/tomcat-tmp:/labkey/files/tomcat-tmp
+      # - ./mounts/files/tomcat-tmp:/labkey/files/tomcat-tmp
       # - files:/labkey/files
       - ./mounts/modules:/labkey/externalModules
       - ./mounts/logs:/labkey/logs
@@ -240,7 +240,7 @@ services:
       - ${HOST_PORT:-8443}:8443
     volumes:
       - ./mounts/files:/labkey/files
-      - ./mounts/files/tomcat-tmp:/labkey/files/tomcat-tmp
+      # - ./mounts/files/tomcat-tmp:/labkey/files/tomcat-tmp
       # - files:/labkey/files
       - ./mounts/modules:/labkey/externalModules
       - ./mounts/logs:/labkey/logs
@@ -350,7 +350,7 @@ services:
       - ${HOST_PORT:-8443}:8443
     volumes:
       - ./mounts/files:/labkey/files
-      - ./mounts/files/tomcat-tmp:/labkey/files/tomcat-tmp
+      # - ./mounts/files/tomcat-tmp:/labkey/files/tomcat-tmp
       # - files:/labkey/files
       - ./mounts/modules:/labkey/externalModules
       - ./mounts/logs:/labkey/logs

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -240,7 +240,7 @@ main() {
 
   fi
 
-  HEAP_DUMP_PATH="$LABKEY_HOME/files/tomcat-tmp/heap_dumps_$(date +%Y%m%d_%H%M%S)"
+  HEAP_DUMP_PATH="$LABKEY_HOME/files/heap_dumps_$(date +%Y%m%d_%H%M%S)"
   mkdir -pv $HEAP_DUMP_PATH
 
   # shellcheck disable=SC2086

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -240,12 +240,16 @@ main() {
 
   fi
 
+  HEAP_DUMP_PATH="$LABKEY_HOME/files/tomcat-tmp/heap_dumps_$(date +%Y%m%d_%H%M%S)"
+  mkdir -pv $HEAP_DUMP_PATH
+
   # shellcheck disable=SC2086
   exec java \
     \
     -Duser.timezone="${JAVA_TIMEZONE}" \
     \
-    -XX:-HeapDumpOnOutOfMemoryError \
+    -XX:+HeapDumpOnOutOfMemoryError \
+    -XX:HeapDumpPath="${HEAP_DUMP_PATH}" \
     \
     -XX:MaxRAMPercentage="${MAX_JVM_RAM_PERCENT}" \
     \

--- a/quickstart_envs.sh
+++ b/quickstart_envs.sh
@@ -3,7 +3,7 @@
 # example minimal set of environment variables to get started - see readme for additional envs you may wish to set
 
 # embedded tomcat LabKey .jar version to build container with
-export LABKEY_VERSION="23.8"
+export LABKEY_VERSION="23.10.0"
 
 # minimal SMTP settings
 export SMTP_HOST="localhost"


### PR DESCRIPTION
the java command had the bit to create a heapdump on OOM, but it would by default remain in the container and be lost. This corrects that by added a timestamped HeapDumpPath in the mounted /labkey/files volume, so each startup gets its own directory for both on the fly and automatic heapdumps. TODO: add a cleanup operation to clear out old heapdump folders/files.

also: add MAX_JVM_RAM_PERCENT env var for use with docker-compose.