### PR TITLE
add content security policy env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,9 @@ ENV CERT_C="US" \
     CERT_OU="IT" \
     CERT_CN="localhost" \
     \
+    CSP_DISPOSITION= \
+    CSP_POLICY= \
+    \
     SMTP_HOST="localhost" \
     SMTP_USER="root" \
     SMTP_PORT="25" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -373,6 +373,9 @@ services:
       - MAX_JVM_RAM_PERCENT=${MAX_JVM_RAM_PERCENT:-75.0}
       - JAVA_PRE_JAR_EXTRA=-XX:+UseSerialGC -Xss512k
 
+      - CSP_DISPOSITION=${CSP_DISPOSITION:-}
+      - CSP_POLICY=${CSP_POLICY:-}
+
       # - SMTP_HOST=mailhog
       # - SMTP_PORT=1025
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -209,7 +209,7 @@ main() {
   sed -i "s/@@jdbcPassword@@/${POSTGRES_PASSWORD:-}/" config/application.properties
 
   # only set up CSP if both vars are defined, otherwise ignore
-  # note: newlines in CSP_POLICY must be double-escaped. 
+  # note: newlines in CSP_POLICY must be double-escaped (or can leave out entirely). 
   #       ex: "default-src 'self' https: ;\\\nconnect-src 'self' https: ;\\\n...
   if [ -n "$CSP_DISPOSITION" ] && [ -n "$CSP_POLICY" ]; then
     echo "csp.disposition=$CSP_DISPOSITION\n" >> config/application.properties

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,10 @@ LOG4J_CONFIG_FILE="${LOG4J_CONFIG_FILE:=log4j2.xml}"
 # below assumes using local log4j2.xml file, as the embedded version is not available for edits until after server is running
 JSON_OUTPUT="${JSON_OUTPUT:-false}"
 
+# Content Security Policy settings
+CSP_DISPOSITION="${CSP_DISPOSITION:-}"
+CSP_POLICY="${CSP_POLICY:-}"
+
 # for ecs/datadog, optionally enable APM metrics
 DD_COLLECT_APM="${DD_COLLECT_APM:-false}"
 
@@ -204,6 +208,14 @@ main() {
   sed -i "s/@@jdbcUser@@/${POSTGRES_USER:-postgres}/" config/application.properties
   sed -i "s/@@jdbcPassword@@/${POSTGRES_PASSWORD:-}/" config/application.properties
 
+  # only set up CSP if both vars are defined, otherwise ignore
+  # note: newlines in CSP_POLICY must be double-escaped. 
+  #       ex: "default-src 'self' https: ;\\\nconnect-src 'self' https: ;\\\n...
+  if [ -n "$CSP_DISPOSITION" ] && [ -n "$CSP_POLICY" ]; then
+    echo "csp.disposition=$CSP_DISPOSITION\n" >> config/application.properties
+    echo "csp.policy=$CSP_POLICY\n" >> config/application.properties
+  fi
+
   sed -i "s/@@smtpHost@@/${SMTP_HOST}/" config/application.properties
   sed -i "s/@@smtpUser@@/${SMTP_USER}/" config/application.properties
   sed -i "s/@@smtpPort@@/${SMTP_PORT}/" config/application.properties
@@ -215,7 +227,7 @@ main() {
   sed -i "s/@@encryptionKey@@/${LABKEY_EK}/" config/application.properties
 
   echo "Purging secrets and other bits from environment variables..."
-  unset POSTGRES_USER POSTGRES_PASSWORD POSTGRES_HOST POSTGRES_PORT POSTGRES_DB POSTGRES_PARAMETERS
+  unset POSTGRES_USER POSTGRES_PASSWORD POSTGRES_HOST POSTGRES_PORT POSTGRES_DB POSTGRES_PARAMETERS CSP_DISPOSITION CSP_POLICY
   unset SMTP_HOST SMTP_USER SMTP_PORT SMTP_PASSWORD SMTP_AUTH SMTP_FROM SMTP_STARTTLS
   unset LABKEY_CREATE_INITIAL_USER LABKEY_CREATE_INITIAL_USER_APIKEY LABKEY_INITIAL_USER_APIKEY LABKEY_INITIAL_USER_EMAIL LABKEY_INITIAL_USER_GROUP LABKEY_INITIAL_USER_ROLE
   unset LABKEY_EK SLEEP


### PR DESCRIPTION
adding CSP_DISPOSITION and CSP_POLICY env vars for defining content security policies in embedded tomcat. 

Note especially that the policy env var is meant to end up in application.properties as 1 line. Newlines appear to be optional, but if included, must be double escaped in the env var as "\\\n". Example: 

CSP_POLICY="default-src 'self' https: ;\\\nconnect-src 'self' https: ;\\\nobject-src 'none' ;\\\nstyle-src 'self' https: 'unsafe-inline' ;\\\nimg-src 'self' data: ;\\\nscript-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-\${REQUEST.SCRIPT.NONCE}';\\\nbase-uri 'self' ;\\\nupgrade-insecure-requests ;\\\nframe-ancestors 'self' ;\\\nreport-to /labkey/admin-contentsecuritypolicyreport.api ;\\\nreport-uri /labkey/admin-contentsecuritypolicyreport.api ;"

Seem to work fine if you leave the newlines out entirely, though.

related:
* https://github.com/LabKey/server/pull/626
* https://github.com/LabKey/terraform_cloud/pull/1280