### PR TITLE
update csp var consumption to match new server settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,8 @@ ENV CERT_C="US" \
     CERT_OU="IT" \
     CERT_CN="localhost" \
     \
-    CSP_DISPOSITION= \
-    CSP_POLICY= \
+    CSP_REPORT= \
+    CSP_ENFORCE= \
     \
     SMTP_HOST="localhost" \
     SMTP_USER="root" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -373,8 +373,8 @@ services:
       - MAX_JVM_RAM_PERCENT=${MAX_JVM_RAM_PERCENT:-75.0}
       - JAVA_PRE_JAR_EXTRA=-XX:+UseSerialGC -Xss512k
 
-      - CSP_DISPOSITION=${CSP_DISPOSITION:-}
-      - CSP_POLICY=${CSP_POLICY:-}
+      - CSP_REPORT=${CSP_REPORT:-}
+      - CSP_ENFORCE=${CSP_ENFORCE:-}
 
       # - SMTP_HOST=mailhog
       # - SMTP_PORT=1025

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,8 +21,8 @@ LOG4J_CONFIG_FILE="${LOG4J_CONFIG_FILE:=log4j2.xml}"
 JSON_OUTPUT="${JSON_OUTPUT:-false}"
 
 # Content Security Policy settings
-CSP_DISPOSITION="${CSP_DISPOSITION:-}"
-CSP_POLICY="${CSP_POLICY:-}"
+CSP_REPORT="${CSP_REPORT:-}"
+CSP_ENFORCE="${CSP_ENFORCE:-}"
 
 # for ecs/datadog, optionally enable APM metrics
 DD_COLLECT_APM="${DD_COLLECT_APM:-false}"
@@ -208,12 +208,13 @@ main() {
   sed -i "s/@@jdbcUser@@/${POSTGRES_USER:-postgres}/" config/application.properties
   sed -i "s/@@jdbcPassword@@/${POSTGRES_PASSWORD:-}/" config/application.properties
 
-  # only set up CSP if both vars are defined, otherwise ignore
-  # note: newlines in CSP_POLICY must be double-escaped (or can leave out entirely). 
-  #       ex: "default-src 'self' https: ;\\\nconnect-src 'self' https: ;\\\n...
-  if [ -n "$CSP_DISPOSITION" ] && [ -n "$CSP_POLICY" ]; then
-    echo "csp.disposition=$CSP_DISPOSITION\n" >> config/application.properties
-    echo "csp.policy=$CSP_POLICY\n" >> config/application.properties
+  # note: leave newlines out of CSP_REPORT/ENFORCE env vars
+  #       ex: "default-src 'self' https: ; connect-src 'self' https: ; ...""
+  if [ -n "$CSP_REPORT" ]; then
+    echo "csp.report=$CSP_REPORT\n" >> config/application.properties
+  fi
+  if [ -n "$CSP_ENFORCE" ]; then
+    echo "csp.enforce=$CSP_ENFORCE\n" >> config/application.properties
   fi
 
   sed -i "s/@@smtpHost@@/${SMTP_HOST}/" config/application.properties
@@ -227,7 +228,7 @@ main() {
   sed -i "s/@@encryptionKey@@/${LABKEY_EK}/" config/application.properties
 
   echo "Purging secrets and other bits from environment variables..."
-  unset POSTGRES_USER POSTGRES_PASSWORD POSTGRES_HOST POSTGRES_PORT POSTGRES_DB POSTGRES_PARAMETERS CSP_DISPOSITION CSP_POLICY
+  unset POSTGRES_USER POSTGRES_PASSWORD POSTGRES_HOST POSTGRES_PORT POSTGRES_DB POSTGRES_PARAMETERS CSP_REPORT CSP_ENFORCE
   unset SMTP_HOST SMTP_USER SMTP_PORT SMTP_PASSWORD SMTP_AUTH SMTP_FROM SMTP_STARTTLS
   unset LABKEY_CREATE_INITIAL_USER LABKEY_CREATE_INITIAL_USER_APIKEY LABKEY_INITIAL_USER_APIKEY LABKEY_INITIAL_USER_EMAIL LABKEY_INITIAL_USER_GROUP LABKEY_INITIAL_USER_ROLE
   unset LABKEY_EK SLEEP


### PR DESCRIPTION
move csp vars to be CSP_REPORT and CSP_ENFORCE to match updates on server side.

* https://github.com/LabKey/terraform_module_ecs_service_lkapps/pull/17
* https://github.com/LabKey/terraform_cloud/pull/1321
* https://github.com/LabKey/Dockerfile/pull/56
* https://github.com/LabKey/server/pull/642