### PR TITLE
bump postgres version to 15 to match current deployments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       - SLEEP=${SLEEP:-0}
 
   pg-community:
-    image: postgres:13
+    image: postgres:15
     # deploy:
     #   resources:
     #     limits:
@@ -198,7 +198,7 @@ services:
       - SLEEP=${SLEEP:-0}
 
   pg-allpg:
-    image: postgres:13
+    image: postgres:15
     # deploy:
     #   resources:
     #     limits:
@@ -307,7 +307,7 @@ services:
       - SLEEP=${SLEEP:-0}
 
   pg-enterprise:
-    image: postgres:13
+    image: postgres:15
     # deploy:
     #   resources:
     #     limits:
@@ -419,7 +419,7 @@ services:
       - SLEEP=${SLEEP:-0}
 
   pg-lims_starter:
-    image: postgres:13
+    image: postgres:15
     # deploy:
     #   resources:
     #     limits:


### PR DESCRIPTION
existing DBs running postgres 13 should export their data before running on pg 15, and re-import. Something akin to [this guide](https://thomasbandt.com/postgres-docker-major-version-upgrade) should work.