### PR TITLE
Fb 49494 disable single instance db protection

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -290,6 +290,7 @@ main() {
     -Dorg.apache.catalina.startup.EXIT_ON_INIT_FAILURE=true \
     \
     -DsynchronousStartup=true \
+    -DterminateOnExistingConnections=false \
     -DterminateOnStartupFailure=true \
     \
     ${DD_JAVA_AGENT} \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -289,7 +289,7 @@ main() {
     \
     -Dorg.apache.catalina.startup.EXIT_ON_INIT_FAILURE=true \
     \
-    -DsynchronousStartup=true \
+    -DsynchronousStartup=false \
     -DterminateOnExistingConnections=false \
     -DterminateOnStartupFailure=true \
     \


### PR DESCRIPTION
#### Rationale

- Adds new system property `terminateOnExistingConnections=false` that allows instance to continue on startup if the application detects more than one labkey instance connected. issueId=49494
- Disables synchronousStartup - which should allow healthcheck to complete while system is starting (e.g long running upgrades etc. ) issueId=49761

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5265


