### PR TITLE
reconcile tomcat logging (requires v24.3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -191,7 +191,7 @@ RUN [ -n "${DEBUG}" ] && set -x; \
         "config" \
         "externalModules" \
         "logs" \
-        "server/startup" \
+        "startup" \
         "${TOMCAT_BASE_DIR}" \
         "/work/Tomcat/localhost" \
     \
@@ -209,10 +209,10 @@ COPY application.properties config/
 
 # add basic + distribution startup properties
 COPY startup/basic.properties \
-    server/startup/50_basic.properties
+    startup/50_basic.properties
 
 COPY "startup/${LABKEY_DISTRIBUTION}.properties" \
-    server/startup/49_distribution.properties
+    startup/49_distribution.properties
 
 # add logging config files
 COPY log4j2.xml log4j2.xml

--- a/application.properties
+++ b/application.properties
@@ -12,6 +12,10 @@ spring.main.banner-mode=off
 spring.application.name=labkey
 server.servlet.application-display-name=labkey
 
+# 2024-02-29 - if enabling logging.config setting, the file must exist at runtime or app will error and quit
+#            - if logging.config and LOG4J_CONFIG_FILE env var are set differently, LOG4J_CONFIG_FILE wins
+# logging.config=${$LOG4J_CONFIG_FILE:log4j2.xml}
+
 # logging.pattern.console=
 logging.pattern.console=%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} E %clr(%-5.5p) %clr(%5.5replace(%p){'.+', ${PID:-}}){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(${LOGGER_PATTERN:-%-40.40logger{39}}){cyan} %clr(:){faint} %m%n%wEx
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ keystore_format="${TOMCAT_KEYSTORE_FORMAT:-}"
 LABKEY_CUSTOM_PROPERTIES_S3_URI="${LABKEY_CUSTOM_PROPERTIES_S3_URI:=none}"
 LABKEY_DEFAULT_PROPERTIES_S3_URI="${LABKEY_DEFAULT_PROPERTIES_S3_URI:=none}"
 
-# set below to 'server/labkeywebapp/WEB-INF/classes/log4j2.xml' to use embedded tomcat version
+# set below to 'labkeywebapp/WEB-INF/classes/log4j2.xml' to use embedded tomcat version
 LOG4J_CONFIG_FILE="${LOG4J_CONFIG_FILE:=log4j2.xml}"
 
 # below assumes using local log4j2.xml file, as the embedded version is not available for edits until after server is running
@@ -133,12 +133,12 @@ main() {
   # optional s3 uris to files with default or custom startup properties, formatted like startup/basic.properties
   if [ $LABKEY_DEFAULT_PROPERTIES_S3_URI != 'none' ]; then
     echo "trying to s3 cp '$LABKEY_DEFAULT_PROPERTIES_S3_URI'"
-    awsclibin/aws s3 cp $LABKEY_DEFAULT_PROPERTIES_S3_URI server/startup/
+    awsclibin/aws s3 cp $LABKEY_DEFAULT_PROPERTIES_S3_URI startup/
   fi
 
   if [ $LABKEY_CUSTOM_PROPERTIES_S3_URI != 'none' ]; then
     echo "trying to s3 cp '$LABKEY_CUSTOM_PROPERTIES_S3_URI'"
-    awsclibin/aws s3 cp $LABKEY_CUSTOM_PROPERTIES_S3_URI server/startup/
+    awsclibin/aws s3 cp $LABKEY_CUSTOM_PROPERTIES_S3_URI startup/
   fi
 
   echo "sleeping for $SLEEP seconds..."
@@ -151,7 +151,7 @@ main() {
   # echo "sleeping for $SLEEP seconds..."
   # sleep $SLEEP
 
-  for prop_file in server/startup/*.properties; do
+  for prop_file in startup/*.properties; do
     envsubst < "$prop_file" > "${prop_file}.tmp" \
       && mv "${prop_file}.tmp" "$prop_file"
   done
@@ -187,7 +187,7 @@ main() {
   if [ -n "${DEBUG:-}" ]; then
     tail -n+1 \
       config/*.properties \
-      server/startup/*.properties \
+      startup/*.properties \
       "${JAVA_HOME:-}"/release
 
     if command -v tree >/dev/null 2>&1; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ keystore_format="${TOMCAT_KEYSTORE_FORMAT:-}"
 LABKEY_CUSTOM_PROPERTIES_S3_URI="${LABKEY_CUSTOM_PROPERTIES_S3_URI:=none}"
 LABKEY_DEFAULT_PROPERTIES_S3_URI="${LABKEY_DEFAULT_PROPERTIES_S3_URI:=none}"
 
-# set below to 'labkeywebapp/WEB-INF/classes/log4j2.xml' to use embedded tomcat version
+# set below to 'labkeywebapp/WEB-INF/classes/log4j2.xml' to use embedded tomcat version from the built .jar
 LOG4J_CONFIG_FILE="${LOG4J_CONFIG_FILE:=log4j2.xml}"
 
 # below assumes using local log4j2.xml file, as the embedded version is not available for edits until after server is running

--- a/log4j2.xml
+++ b/log4j2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<Configuration packages="org.labkey.api.util">
+<Configuration packages="org.labkey.api.util,org.labkey.embedded">
 
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">
@@ -26,20 +26,9 @@
                 <SizeBasedTriggeringPolicy size="100 MB"/>
             </Policies>
             <DefaultRolloverStrategy fileIndex="min">
-                <Delete basePath="${sys:labkey.log.home}">
-                    <ScriptCondition>
-                        <!-- Use custom Java code to retain the first log file from the current session if it's about
-                        to be rotated out. It may have root cause information about problems that would otherwise be lost -->
-                        <Script name="retainFirst" language="rhino"><![CDATA[
-                                var ErrorLogRotator = org.labkey.api.util.logging.ErrorLogRotator;
-                                var rotator = new ErrorLogRotator();
-                                rotator.filter(pathList);
-                            ]]>
-                        </Script>
-                    </ScriptCondition>
-                </Delete>
+                <LabKeyDelete basePath="${sys:labkey.log.home}">
+                </LabKeyDelete>
             </DefaultRolloverStrategy>
-
         </RollingFile>
 
         <RollingFile name="ACTION_STATS"
@@ -138,22 +127,59 @@
             <DefaultRolloverStrategy fileIndex="min" />
         </RollingFile>
 
+        <RollingFile name="CSP_REPORT"
+                     fileName="${sys:labkey.log.home}/csp-report.log"
+                     append="true"
+                     filePattern="${sys:labkey.log.home}/csp-report.log.%i">
+            <!-- p=priority c=category d=datetime t=thread m=message n=newline -->
+            <PatternLayout>
+                <Pattern>%-5p %-24.24c{1} %d{ISO8601} %24.24t : %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="10 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy fileIndex="min" />
+        </RollingFile>
+
+        <RollingFile name="INDEXED_DOCUMENTS"
+                     fileName="${sys:labkey.log.home}/labkey-indexed-documents.log"
+                     append="true"
+                     bufferedIO="false"
+                     filePattern="${sys:labkey.log.home}/labkey-indexed-documents.log.%i">
+            <!-- d=datetime m=message n=newline -->
+            <PatternLayout>
+                <Pattern>%d{ISO8601} %m%n</Pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="1 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="3" fileIndex="min" />
+        </RollingFile>
+
     </Appenders>
 
     <Loggers>
+        <!--
+            Set all packages to INFO level (org.labkey, org.fhcrc, third-party dependencies) by default
+            and send errors to the labkey-errors.log as well.
+        -->
+        <Root level="info">
+            <AppenderRef ref="CONSOLE"/>
+            <AppenderRef ref="LABKEY"/>
+            <AppenderRef ref="ERRORS"/>
+        </Root>
 
         <!-- category for server side script messages -->
-        <Logger name="org.labkey.api.script.ScriptService.Console" level="${env:LOG_LEVEL_API_SETTINGS:-INFO}">
+        <Logger name="org.labkey.api.script.ScriptService.Console" level="info">
             <AppenderRef ref="SessionAppender"/>
         </Logger>
-
 
         <!-- category for Mule messages -->
         <Logger name="org.mule.MuleManager" level="info"/>
 
         <!--
             <Logger name="org.labkey.pipeline.mule.transformers" level="debug"/>
-         -->
+        -->
 
         <!-- category for jasper messages -->
         <Logger name="org.apache.jasper" level="warn"/>
@@ -161,11 +187,7 @@
         <!-- application classes -->
         <Logger name="org.fhcrc" level="info"/>
 
-
-        <Logger name="org.labkey" level="${env:LOG_LEVEL_LABKEY_DEFAULT:-INFO}">
-            <AppenderRef ref="CONSOLE"/>
-            <AppenderRef ref="LABKEY"/>
-        </Logger>
+        <Logger name="org.labkey" level="${env:LOG_LEVEL_LABKEY_DEFAULT:-INFO}" />
 
         <!-- uncomment to enable 'DEBUG' level on external SAML libraries to troubleshoot.
         Note: you will also have to set dependency on slf4j lib in saml/build.gradle - uncomment 'slf4j' external libraries and build
@@ -190,12 +212,13 @@
         -->
 
         <!-- only show errors from PipelineJob output -->
-        <Logger name="org.labkey.api.pipeline.PipelineJob" level="error">
-            <!-- <AppenderRef ref="CONSOLE"/> -->
-        </Logger>
+        <Logger name="org.labkey.api.pipeline.PipelineJob" level="error"/>
 
         <!-- don't need to log PDFBox errors (e.g., FlateFilter, PDCIDFontType2) -->
         <Logger name="org.apache.pdfbox" level="fatal"/>
+
+        <!-- Suppress EHCache "maxElementsInMemory of 0" warnings, Issue 49593 -->
+        <Logger name="net.sf.ehcache.config.CacheConfiguration" level="error"/>
 
         <!-- this is a very verbose logger for security/permissions checking -->
         <!--
@@ -218,7 +241,6 @@
         </Logger>
 
         <Logger name="org.labkey.rstudio" level="info"/>
-
 
         <!--
             <Logger name="org.labkey.api.cache" level="debug"/>
@@ -244,12 +266,21 @@
             <Logger name="org.labkey.search.model.LuceneSearchServiceImpl" level="debug"/>
         -->
 
-        <Logger name="org.labkey.api.util.MemTracker" additivity="false" level="${env:LOG_LEVEL_LABKEY_DEFAULT:-DEBUG}">
+        <Logger name="org.labkey.api.util.MemTracker" additivity="false" level="debug">
             <AppenderRef ref="LABKEYMemory"/>
         </Logger>
 
-        <Logger name="org.labkey.api.util.DebugInfoDumper" level="${env:LOG_LEVEL_LABKEY_DEFAULT:-DEBUG}">
+        <Logger name="org.labkey.api.search.SearchService$SearchCategory" additivity="false" level="info">
+            <AppenderRef ref="INDEXED_DOCUMENTS"/>
+        </Logger>
+
+        <Logger name="org.labkey.api.util.DebugInfoDumper" level="debug">
             <AppenderRef ref="THREAD_DUMP"/>
+        </Logger>
+
+        <Logger name="org.labkey.core.admin.AdminController.ContentSecurityPolicyReportAction"  additivity="false" level="warn">
+            <AppenderRef ref="CSP_REPORT" />
+            <AppenderRef ref="CONSOLE"/>
         </Logger>
 
         <!--
@@ -272,7 +303,7 @@
 
         <Logger name="org.labkey.audit.event" level="OFF">
             <AppenderRef ref="LABKEY_AUDIT"/>
-            <!-- <AppenderRef ref="CONSOLE"/> -->
+            <AppenderRef ref="CONSOLE"/>
         </Logger>
 
         <!--
@@ -299,20 +330,15 @@
             SearchAuditEvent
             SelectQuery
          To enable logging of all events, set the level for the org.labkey.audit.event to
-         something other than "OFF".  To enable individual audit event logging, configure the
+         something other than "OFF". To enable individual audit event logging, configure the
          individual stanza like the one shown below, where you prefix the audit event type
          with 'org.labkey.audit.event'. Then set the level to INFO and specify the appenders.
         -->
         <Logger name="org.labkey.audit.event.UserAuditEvent" additivity="false" level="OFF">
             <AppenderRef ref="LABKEY_AUDIT"/>
-            <!-- <AppenderRef ref="CONSOLE"/> -->
+            <AppenderRef ref="CONSOLE"/>
         </Logger>
 
         <Logger name="NoOpLogger" level="OFF" additivity="false"/>
-
-        <Root level="${env:LOG_LEVEL_DEFAULT:-FATAL}">
-            <!-- <AppenderRef ref="CONSOLE"/> -->
-            <AppenderRef ref="ERRORS"/>
-        </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
#### Rationale
need to bring Dockerfile's log4j2.xml in line w/ latest updates in the [built version](https://github.com/LabKey/server/commit/0d70ba8bc827416a4b07914a4ea75c8ba613ee81).

Note: requires version 24.3 of LabKey.

#### Related Pull Requests
* https://github.com/LabKey/Dockerfile/pull/62

#### Changes
* add optional `logging.config` to application.properties. Note: file it points to must exist prior to app starting, and LOG4J_CONFIG_FILE env var takes precedence anyway.
* tchad's not-yet-merged change to remove server/ from directories.
