### PR TITLE
set bootstrap full text index path

### DIFF
--- a/startup/basic.properties
+++ b/startup/basic.properties
@@ -15,4 +15,6 @@ SiteSettings.pipelineToolsDirectory;bootstrap=${LABKEY_HOME}
 SiteSettings.sslPort;startup=${LABKEY_PORT}
 SiteSettings.sslRequired;startup=true
 
+SearchSettings.indexFilePath;bootstrap=${LABKEY_FILES_ROOT}/labkey_full_text_index
+
 ${LABKEY_STARTUP_BASIC_EXTRA}


### PR DESCRIPTION
#### Rationale
Full text index path is set to ephemeral storage and discarded with each restart


#### Changes
* Sets bootstrap value to place index on file path mount that persists
* Fixes issue 49582 for new deployments 
