### PR TITLE
stop installing tomcat native library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,7 +125,6 @@ RUN [ -n "${DEBUG}" ] && set -x; \
     if echo "${FROM_TAG}" | grep -i 'alpine'; then \
         apk update \
         && apk add --no-cache \
-            tomcat-native=2.0.3-r0 \
             openssl=3.1.1-r1 \
             gettext=0.21.1-r7 \
             unzip=6.0-r14 \
@@ -148,7 +147,6 @@ RUN [ -n "${DEBUG}" ] && set -x; \
         export DEBIAN_FRONTEND=noninteractive; \
         apt-get update; \
         apt-get -yq --no-install-recommends install \
-            libtcnative-1=1.2.31-1build1 \
             openssl=3.0.2-0ubuntu1.14 \
             gettext-base=0.21-4ubuntu4 \
             unzip=6.0-26ubuntu3.1 \

--- a/startup/basic.properties
+++ b/startup/basic.properties
@@ -15,4 +15,6 @@ SiteSettings.pipelineToolsDirectory;bootstrap=${LABKEY_HOME}
 SiteSettings.sslPort;startup=${LABKEY_PORT}
 SiteSettings.sslRequired;startup=true
 
+SearchSettings.indexFilePath;bootstrap=${LABKEY_FILES_ROOT}/labkey_full_text_index
+
 ${LABKEY_STARTUP_BASIC_EXTRA}


### PR DESCRIPTION
#### Rationale
Ubuntu 22.04's tomcat native library stops at v1.2.31, which conflicts with the embedded version 1.2.34, causing this error: `SEVERE: An incompatible version [1.2.31] of the Apache Tomcat Native library is installed, while Tomcat requires version [1.2.34]`. 

As the native library is not necessary (and against LabKey's [recommendations](https://www.labkey.org/Documentation/wiki-page.view?name=supported) anyway), it should not be installed in the image.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
