### PR TITLE
bump openssl version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,7 @@ RUN [ -n "${DEBUG}" ] && set -x; \
         export DEBIAN_FRONTEND=noninteractive; \
         apt-get update; \
         apt-get -yq --no-install-recommends install \
-            openssl=3.0.2-0ubuntu1.14 \
+            openssl=3.0.2-0ubuntu1.15 \
             gettext-base=0.21-4ubuntu4 \
             unzip=6.0-26ubuntu3.1 \
             ; \


### PR DESCRIPTION
#### Rationale
OpenSSL version requires update - bump to openssl_3.0.2-0ubuntu1.15
