### PR TITLE
24.3 fb fix jarfile name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -199,7 +199,7 @@ RUN [ -n "${DEBUG}" ] && set -x; \
     chown -Rc labkey:labkey "${LABKEY_HOME}";
 
 
-COPY "labkeyServer-${LABKEY_VERSION}.jar" \
+COPY "labkeyServer.jar" \
     "app.jar"
 
 # add spring properties

--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,7 @@ RUN [ -n "${DEBUG}" ] && set -x; \
         export DEBIAN_FRONTEND=noninteractive; \
         apt-get update; \
         apt-get -yq --no-install-recommends install \
-            openssl=3.0.2-0ubuntu1.14 \
+            openssl=3.0.2-0ubuntu1.15 \
             gettext-base=0.21-4ubuntu4 \
             unzip=6.0-26ubuntu3.1 \
             ; \

--- a/startup/basic.properties
+++ b/startup/basic.properties
@@ -15,4 +15,6 @@ SiteSettings.pipelineToolsDirectory;bootstrap=${LABKEY_HOME}
 SiteSettings.sslPort;startup=${LABKEY_PORT}
 SiteSettings.sslRequired;startup=true
 
+SearchSettings.indexFilePath;bootstrap=${LABKEY_FILES_ROOT}/labkey_full_text_index
+
 ${LABKEY_STARTUP_BASIC_EXTRA}


### PR DESCRIPTION
#### Rationale
Update labkeyServer.jar file name to match removal of the version number from Jar file. 
