### PR TITLE
24.3 fb remove rename of labkeyServer.jar to app.jar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -199,7 +199,7 @@ RUN [ -n "${DEBUG}" ] && set -x; \
     chown -Rc labkey:labkey "${LABKEY_HOME}";
 
 
-COPY "labkeyServer.jar" \
+COPY "labkeyServer.jar" "${LABKEY_HOME}"
 
 # add spring properties
 COPY application.properties config/

--- a/Dockerfile
+++ b/Dockerfile
@@ -200,7 +200,6 @@ RUN [ -n "${DEBUG}" ] && set -x; \
 
 
 COPY "labkeyServer.jar" \
-    "app.jar"
 
 # add spring properties
 COPY application.properties config/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -297,7 +297,7 @@ main() {
     \
     ${JAVA_PRE_JAR_EXTRA} \
     \
-    -jar app.jar \
+    -jar labkeyServer.jar \
     \
     ${JAVA_POST_JAR_EXTRA} \
     \


### PR DESCRIPTION
#### Rationale
`labkeyServer.jar` file was being renamed during the Dockerfile build - presumably due to previous installers appending a version number with each release.  This PR removes the rename and preserves the jar file as `labkeyServer.jar`

#### Related Pull Requests
* https://github.com/LabKey/Dockerfile/pull/75
