### PR TITLE
update GH actions to run on release branches and release targeted FBs

### DIFF
--- a/.github/workflows/dockle_xeol.yml
+++ b/.github/workflows/dockle_xeol.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - fb_*
+      - '*_fb_*'
 
   pull_request:
     branches:
       - develop
+      - 'release*'
 
 jobs:
   dockle:

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - fb_*
+      - '*_fb_*'
 
   pull_request:
     branches:
       - develop
+      - 'release*'
 
 jobs:
   hadolint:


### PR DESCRIPTION
#### Rationale
Github actions were not triggering on new PR's that target release branches or use the release branch targeting naming convention. 

