### PR TITLE
Use updated syntax for labkeyDataSource in application.properties

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -78,28 +78,22 @@ logging.level.org.apache.tomcat.util.digester.Digester=INFO
 # logging.level.org.springframework.boot.autoconfigure.condition=INFO
 # logging.level.org.springframework.core.env.PropertySourcesPropertyResolver=INFO
 
-context.dataSourceName[0]=jdbc/labkeyDataSource
-context.driverClassName[0]=org.postgresql.Driver
-# context.url[0]=jdbc:postgresql://${POSTGRES_HOST:-localhost}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-${POSTGRES_USER}}${POSTGRES_PARAMETERS:-}
-# context.username[0]=${POSTGRES_USER:-postgres}
-# context.password[0]=${POSTGRES_PASSWORD:-}
+context.resources.jdbc.labkeyDataSource.type=javax.sql.DataSource
+context.resources.jdbc.labkeyDataSource.driverClassName=org.postgresql.Driver
+# context.resources.jdbc.labkeyDataSource.url=jdbc:postgresql://${POSTGRES_HOST:-localhost}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-${POSTGRES_USER}}${POSTGRES_PARAMETERS:-}
+# context.resources.jdbc.labkeyDataSource.username=${POSTGRES_USER:-postgres}
+# context.resources.jdbc.labkeyDataSource.password=${POSTGRES_PASSWORD:-}
 
-context.url[0]=@@jdbcUrl@@
-context.username[0]=@@jdbcUser@@
-context.password[0]=@@jdbcPassword@@
+context.resources.jdbc.labkeyDataSource.url=@@jdbcUrl@@
+context.resources.jdbc.labkeyDataSource.username=@@jdbcUser@@
+context.resources.jdbc.labkeyDataSource.password=@@jdbcPassword@@
 
 # the ':-' setup doesn't appeear to work. They have to be set as env vars anyway, but at least this shows the indended defaults set elsewhere
-context.maxTotal[0]=${POSTGRES_MAX_TOTAL_CONNECTIONS:-50}
-context.maxIdle[0]=${POSTGRES_MAX_IDLE_CONNECTIONS:-10}
-context.maxWaitMillis[0]=${POSTGRES_MAX_WAIT_MILLIS:-120000}
-context.accessToUnderlyingConnectionAllowed[0]=${POSTGRES_ACCESS_UNDERLYING_CONNECTIONS:-true}
-context.validationQuery[0]=${POSTGRES_VALIDATION_QUERY:-SELECT 1}
-
-# context.dataSourceName[1]=jdbc/@@extraJdbcDataSource@@
-# context.driverClassName[1]=@@extraJdbcDriverClassName@@
-# context.url[1]=@@extraJdbcURL@@
-# context.username[1]=@@extraJdbcUser@@
-# context.password[1]=@@extraJdbcPassword@@
+context.resources.jdbc.labkeyDataSource.maxTotal=${POSTGRES_MAX_TOTAL_CONNECTIONS:-50}
+context.resources.jdbc.labkeyDataSource.maxIdle=${POSTGRES_MAX_IDLE_CONNECTIONS:-10}
+context.resources.jdbc.labkeyDataSource.maxWaitMillis=${POSTGRES_MAX_WAIT_MILLIS:-120000}
+context.resources.jdbc.labkeyDataSource.accessToUnderlyingConnectionAllowed=${POSTGRES_ACCESS_UNDERLYING_CONNECTIONS:-true}
+context.resources.jdbc.labkeyDataSource.validationQuery=${POSTGRES_VALIDATION_QUERY:-SELECT 1}
 
 # send access logs to stdout:
 server.tomcat.accesslog.enabled=true


### PR DESCRIPTION
#### Rationale
We updated the syntax for defining data sources in 24.3. We still support the old syntax but should stop using it so that we can remove support eventually.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/713

#### Changes
* Use updated syntax for labkeyDataSource in application.properties 
