### PR TITLE
add  additivity="false" where missing to prevent double logs

### DIFF
--- a/log4j2.xml
+++ b/log4j2.xml
@@ -170,24 +170,24 @@
         </Root>
 
         <!-- category for server side script messages -->
-        <Logger name="org.labkey.api.script.ScriptService.Console" level="info">
+        <Logger name="org.labkey.api.script.ScriptService.Console" additivity="false" level="info">
             <AppenderRef ref="SessionAppender"/>
         </Logger>
 
         <!-- category for Mule messages -->
-        <Logger name="org.mule.MuleManager" level="info"/>
+        <Logger name="org.mule.MuleManager" additivity="false" level="info"/>
 
         <!--
             <Logger name="org.labkey.pipeline.mule.transformers" level="debug"/>
         -->
 
         <!-- category for jasper messages -->
-        <Logger name="org.apache.jasper" level="warn"/>
+        <Logger name="org.apache.jasper" additivity="false" level="warn"/>
 
         <!-- application classes -->
-        <Logger name="org.fhcrc" level="info"/>
+        <Logger name="org.fhcrc" additivity="false" level="info"/>
 
-        <Logger name="org.labkey" level="${env:LOG_LEVEL_LABKEY_DEFAULT:-INFO}" />
+        <Logger name="org.labkey" additivity="false" level="${env:LOG_LEVEL_LABKEY_DEFAULT:-INFO}" />
 
         <!-- uncomment to enable 'DEBUG' level on external SAML libraries to troubleshoot.
         Note: you will also have to set dependency on slf4j lib in saml/build.gradle - uncomment 'slf4j' external libraries and build
@@ -201,7 +201,7 @@
             <AppenderRef ref="LABKEY"/>
         </Logger> -->
 
-        <Logger name="mondrian." level="info" />
+        <Logger name="mondrian." additivity="false" level="info" />
 
         <!--
             <Logger name="org.labkey.wiki" level="debug"/>
@@ -212,13 +212,13 @@
         -->
 
         <!-- only show errors from PipelineJob output -->
-        <Logger name="org.labkey.api.pipeline.PipelineJob" level="error"/>
+        <Logger name="org.labkey.api.pipeline.PipelineJob" additivity="false" level="error"/>
 
         <!-- don't need to log PDFBox errors (e.g., FlateFilter, PDCIDFontType2) -->
-        <Logger name="org.apache.pdfbox" level="fatal"/>
+        <Logger name="org.apache.pdfbox" additivity="false" level="fatal"/>
 
         <!-- Suppress EHCache "maxElementsInMemory of 0" warnings, Issue 49593 -->
-        <Logger name="net.sf.ehcache.config.CacheConfiguration" level="error"/>
+        <Logger name="net.sf.ehcache.config.CacheConfiguration" additivity="false" level="error"/>
 
         <!-- this is a very verbose logger for security/permissions checking -->
         <!--
@@ -232,15 +232,15 @@
             <Logger name="org.labkey.api.data.Table" level="debug"/>
         -->
 
-        <Logger name="org.labkey.api.data"/>
+        <Logger name="org.labkey.api.data" additivity="false"/>
 
-        <Logger name="org.labkey.api.dataiterator"/>
+        <Logger name="org.labkey.api.dataiterator" additivity="false"/>
 
-        <Logger name="org.labkey.docker">
+        <Logger name="org.labkey.docker" additivity="false">
             <level value="info"/>
         </Logger>
 
-        <Logger name="org.labkey.rstudio" level="info"/>
+        <Logger name="org.labkey.rstudio" additivity="false" level="info"/>
 
         <!--
             <Logger name="org.labkey.api.cache" level="debug"/>
@@ -274,7 +274,7 @@
             <AppenderRef ref="INDEXED_DOCUMENTS"/>
         </Logger>
 
-        <Logger name="org.labkey.api.util.DebugInfoDumper" level="debug">
+        <Logger name="org.labkey.api.util.DebugInfoDumper" additivity="false" level="debug">
             <AppenderRef ref="THREAD_DUMP"/>
         </Logger>
 
@@ -288,7 +288,7 @@
         -->
 
         <!--
-            <Logger name="org.labkey" level="debug">
+            <Logger name="org.labkey" additivity="false" level="debug">
                 <AppenderRef ref="SESSION"/>
             </Logger>
          -->
@@ -301,7 +301,7 @@
             <AppenderRef ref="QUERY_STATS"/>
         </Logger>
 
-        <Logger name="org.labkey.audit.event" level="OFF">
+        <Logger name="org.labkey.audit.event" additivity="false" level="OFF">
             <AppenderRef ref="LABKEY_AUDIT"/>
             <AppenderRef ref="CONSOLE"/>
         </Logger>


### PR DESCRIPTION
#### Rationale
the `<Root level="info">` block at the start of the Loggers could cause the subsequent calls to create double logs.  Setting`additivity="false"`  will prevent that.

https://logging.apache.org/log4j/2.x/manual/configuration.html#Additivity

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
