### PR TITLE
undo additivity=false for org.labkey

### DIFF
--- a/log4j2.xml
+++ b/log4j2.xml
@@ -187,7 +187,7 @@
         <!-- application classes -->
         <Logger name="org.fhcrc" additivity="false" level="info"/>
 
-        <Logger name="org.labkey" additivity="false" level="${env:LOG_LEVEL_LABKEY_DEFAULT:-INFO}" />
+        <Logger name="org.labkey" level="${env:LOG_LEVEL_LABKEY_DEFAULT:-INFO}" />
 
         <!-- uncomment to enable 'DEBUG' level on external SAML libraries to troubleshoot.
         Note: you will also have to set dependency on slf4j lib in saml/build.gradle - uncomment 'slf4j' external libraries and build


### PR DESCRIPTION
#### Rationale
additivity=false was added to the loggers in https://github.com/LabKey/Dockerfile/pull/97 , but adding it at the org.labkey level meant there were NO logs coming through. This corrects that mistake.

#### Related Pull Requests
* https://github.com/LabKey/Dockerfile/pull/97

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
