### PR TITLE
pin jammy, bump openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,7 +150,7 @@ RUN [ -n "${DEBUG}" ] && set -x; \
         export DEBIAN_FRONTEND=noninteractive; \
         apt-get update; \
         apt-get -yq --no-install-recommends install \
-            openssl=3.0.2-0ubuntu1.15 \
+            openssl=3.0.2-0ubuntu1.16 \
             gettext-base=0.21-4ubuntu4 \
             unzip=6.0-26ubuntu3.1 \
             ; \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ endif
 
 DEBUG ?=
 
-FROM_TAG ?= 17-jre
+FROM_TAG ?= 17-jre-jammy
 
 CACHE_FLAG ?= --no-cache
 


### PR DESCRIPTION
#### Rationale
* openssl needs a version bump
* missed a spot in an earlier PR to pin 17-jre to the jammy release

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
