### PR TITLE
bump openssl to .17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,7 +150,7 @@ RUN [ -n "${DEBUG}" ] && set -x; \
         export DEBIAN_FRONTEND=noninteractive; \
         apt-get update; \
         apt-get -yq --no-install-recommends install \
-            openssl=3.0.2-0ubuntu1.16 \
+            openssl=3.0.2-0ubuntu1.17 \
             gettext-base=0.21-4ubuntu4 \
             unzip=6.0-26ubuntu3.1 \
             ; \


### PR DESCRIPTION
#### Rationale
Openssl package was updated from .16 to .17 
