### PR TITLE
update accesslog.pattern to match server defaults

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -94,21 +94,22 @@ context.resources.jdbc.labkeyDataSource.maxWaitMillis=${POSTGRES_MAX_WAIT_MILLIS
 context.resources.jdbc.labkeyDataSource.accessToUnderlyingConnectionAllowed=${POSTGRES_ACCESS_UNDERLYING_CONNECTIONS}
 context.resources.jdbc.labkeyDataSource.validationQuery=${POSTGRES_VALIDATION_QUERY}
 
-# send access logs to stdout:
-server.tomcat.accesslog.enabled=true
-server.tomcat.accesslog.directory=/dev
-server.tomcat.accesslog.prefix=stdout
-server.tomcat.accesslog.buffered=false
-server.tomcat.accesslog.suffix=
-server.tomcat.accesslog.file-date-format=
-
 # send access logs to file:
 # server.tomcat.accesslog.directory=/tmp
 # server.tomcat.accesslog.enabled=true
 # server.tomcat.accesslog.prefix=access
 # server.tomcat.accesslog.suffix=.log
 # server.tomcat.accesslog.rotate=false
-# # server.tomcat.accesslog.pattern=%{org.apache.catalina.AccessLog.RemoteAddr}r %l %u %t "%r" %s %b %D %S "%{Referer}i" "%{User-Agent}i" %{LABKEY.username}s %q
+## File-based Tomcat HTTP access logs are enabled by default and use our recommended pattern. Override as needed.
+# server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %S %I "%{Referer}i" "%{User-Agent}i" %{LABKEY.username}s %{X-Forwarded-For}i
+
+# send access logs to stdout (preferred for ECS):
+server.tomcat.accesslog.enabled=true
+server.tomcat.accesslog.directory=/dev
+server.tomcat.accesslog.prefix=stdout
+server.tomcat.accesslog.buffered=false
+server.tomcat.accesslog.suffix=
+server.tomcat.accesslog.file-date-format=
 
 server.http2.enabled=true
 


### PR DESCRIPTION
#### Rationale
the `server.tomcat.accesslog.pattern` property was already commented out, as we log to stdout by default in our containers, but this updates the commented out file-based logging pattern to match the new default in the server repo, and re-orders the settings blocks to make a bit more sense.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/877

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
