### PR TITLE
bump openssl to version 3.0.2-0ubuntu1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,7 +150,7 @@ RUN [ -n "${DEBUG}" ] && set -x; \
         export DEBIAN_FRONTEND=noninteractive; \
         apt-get update; \
         apt-get -yq --no-install-recommends install \
-            openssl=3.0.2-0ubuntu1.17 \
+            openssl=3.0.2-0ubuntu1.18 \
             gettext-base=0.21-4ubuntu4 \
             unzip=6.0-26ubuntu3.1 \
             ; \

--- a/application.properties
+++ b/application.properties
@@ -94,21 +94,22 @@ context.resources.jdbc.labkeyDataSource.maxWaitMillis=${POSTGRES_MAX_WAIT_MILLIS
 context.resources.jdbc.labkeyDataSource.accessToUnderlyingConnectionAllowed=${POSTGRES_ACCESS_UNDERLYING_CONNECTIONS}
 context.resources.jdbc.labkeyDataSource.validationQuery=${POSTGRES_VALIDATION_QUERY}
 
-# send access logs to stdout:
-server.tomcat.accesslog.enabled=true
-server.tomcat.accesslog.directory=/dev
-server.tomcat.accesslog.prefix=stdout
-server.tomcat.accesslog.buffered=false
-server.tomcat.accesslog.suffix=
-server.tomcat.accesslog.file-date-format=
-
 # send access logs to file:
 # server.tomcat.accesslog.directory=/tmp
 # server.tomcat.accesslog.enabled=true
 # server.tomcat.accesslog.prefix=access
 # server.tomcat.accesslog.suffix=.log
 # server.tomcat.accesslog.rotate=false
-# # server.tomcat.accesslog.pattern=%{org.apache.catalina.AccessLog.RemoteAddr}r %l %u %t "%r" %s %b %D %S "%{Referer}i" "%{User-Agent}i" %{LABKEY.username}s %q
+## File-based Tomcat HTTP access logs are enabled by default and use our recommended pattern. Override as needed.
+# server.tomcat.accesslog.pattern=%h %l %u %t "%r" %s %b %D %S %I "%{Referer}i" "%{User-Agent}i" %{LABKEY.username}s %{X-Forwarded-For}i
+
+# send access logs to stdout (preferred for ECS):
+server.tomcat.accesslog.enabled=true
+server.tomcat.accesslog.directory=/dev
+server.tomcat.accesslog.prefix=stdout
+server.tomcat.accesslog.buffered=false
+server.tomcat.accesslog.suffix=
+server.tomcat.accesslog.file-date-format=
 
 server.http2.enabled=true
 


### PR DESCRIPTION
#### Rationale
this also includes a benign update to the commented out accesslog.pattern

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
