### PR TITLE
add readOnlyhttprequesttimeout startup prop

### DIFF
--- a/startup/basic.properties
+++ b/startup/basic.properties
@@ -17,5 +17,6 @@ SiteSettings.sslRequired;startup=true
 FileLinkMetrics.EnableFileLinkMetricsTask;startup=true
 
 SearchSettings.indexFilePath;bootstrap=${LABKEY_FILES_ROOT}/labkey_full_text_index
+SiteSettings.readOnlyHttpRequestTimeout;startup=605
 
 ${LABKEY_STARTUP_BASIC_EXTRA}


### PR DESCRIPTION
#### Rationale
Adds default startup property for SiteSettings.readOnlyHttpRequestTimeout (startup) to help address DB query timeouts issue linked below

https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=50814

https://github.com/LabKey/platform/pull/6061
