### PR TITLE
update for datadog 7.60.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG FROM_TAG=17-jre-jammy
 # uncomment for alpine-based eclipse-temurin jre
 # ARG FROM_TAG=17-jre-alpine
 
-FROM ${FROM_REPO_IMAGE}:${FROM_TAG} as base
+FROM ${FROM_REPO_IMAGE}:${FROM_TAG} AS base
 
 LABEL maintainer="LabKey Systems Engineering <ops@labkey.com>"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: "3"
 
 services:
   community:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -245,7 +245,7 @@ main() {
     export DD_AGENT_HOST=$(curl --max-time 3 -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/local-ipv4);
 
     echo "Adding -javaagent and jmx settings to java command"
-    export DD_JAVA_AGENT="-javaagent:./datadog/dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.logs.injection=true -XX:FlightRecorderOptions=stackdepth=256"
+    export DD_JAVA_AGENT="-javaagent:./datadog/dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.logs.injection=true -XX:FlightRecorderOptions=stackdepth=256 -Ddd.trace.remove.integration-service-names.enabled=true"
 
     export DD_JMX="-Dspring.jmx.enabled=true \
         -Dcom.sun.management.jmxremote \


### PR DESCRIPTION
#### Rationale
[datadog agent 7.60.0](https://github.com/DataDog/datadog-agent/releases/tag/7.60.0) recommends adding `dd.trace.remove.integration-service-names.enabled` to `true` for the tracer agent. This does so.

Plus a little housekeeping.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
