### PR TITLE
bump dockle version and re-enable

### DIFF
--- a/.github/workflows/dockle_xeol.yml
+++ b/.github/workflows/dockle_xeol.yml
@@ -17,27 +17,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-      # - name: Build an image from Dockerfile
-      #   run: |
-      #     cp labkeyServer-HelloWorld.jar labkeyServer.jar
-      #     LABKEY_VERSION=HelloWorld make build
-      # - name: Run dockle on helloworld image
-      #   uses: goodwithtech/dockle-action@0.1.0
-      #   env:
-      #     DOCKER_CONTENT_TRUST: 0
-      #   with:
-      #     image: 'labkey/community:helloworld'
-      #     format: 'list'
-      #     exit-code: '1'
-      #     exit-level: 'warn'
-      #     ignore: 'CIS-DI-0005,CIS-DI-0009,CIS-DI-0010,DKL-DI-0001'
-      # - name: Run xeol on helloworld image
-      #   uses: noqcks/xeol-action@v1.0.6
-      #   with:
-      #     image: "labkey/community:helloworld"
+        uses: actions/checkout@v4
+      - name: Build an image from Dockerfile
+        run: |
+          cp labkeyServer-HelloWorld.jar labkeyServer.jar
+          LABKEY_VERSION=HelloWorld make build
+      - name: Run dockle on helloworld image
+        uses: goodwithtech/dockle-action@v0.4.15
+        env:
+          DOCKER_CONTENT_TRUST: 0
+        with:
+          image: 'labkey/community:helloworld'
+          format: 'list'
+          exit-code: '1'
+          exit-level: 'warn'
+          ignore: 'CIS-DI-0005,CIS-DI-0009,CIS-DI-0010,DKL-DI-0001'
+      - name: Run xeol on helloworld image
+        uses: noqcks/xeol-action@v1.1.1
+        with:
+          image: "labkey/community:helloworld"
       - name: Run xeol on dir
-        uses: noqcks/xeol-action@v1.0.6
+        uses: noqcks/xeol-action@v1.1.1
         with:
           path: "."
   


### PR DESCRIPTION
#### Rationale
the dockle github action had a bug for a long while that is finally fixed. This updates to that version (and latest xeol action version) to re-enable security checks against the image.

* https://github.com/goodwithtech/dockle-action
* https://github.com/xeol-io/xeol-action

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
