### PR TITLE
bump base image from 22.04 to 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # main eclipse-temurin jre, which is debian-based
 ARG FROM_REPO_IMAGE=eclipse-temurin
-ARG FROM_TAG=17-jre-jammy
+ARG FROM_TAG=17-jre-noble
 
 # uncomment for alpine-based eclipse-temurin jre
 # ARG FROM_TAG=17-jre-alpine
@@ -151,8 +151,8 @@ RUN [ -n "${DEBUG}" ] && set -x; \
         apt-get update; \
         apt-get -yq --no-install-recommends install \
             openssl \
-            gettext-base=0.21-4ubuntu4 \
-            unzip=6.0-26ubuntu3.1 \
+            gettext-base=0.21-14ubuntu2 \
+            unzip=6.0-28ubuntu4.1 \
             ; \
         if [ -n "${DEBUG}" ]; then \
             # next 2 lines are to get postgres15 to install on ubuntu 22.04
@@ -160,13 +160,13 @@ RUN [ -n "${DEBUG}" ] && set -x; \
             wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | tee /etc/apt/trusted.gpg.d/pgdg.asc > /dev/null 2>&1; \
             apt-get update; \
             apt-get -yq --no-install-recommends install \
-                iputils-ping=3:20211215-1 \
-                less=590-1ubuntu0.22.04.1 \
-                netcat=1.218-4ubuntu1 \
-                postgresql-client-15=15.5-1.pgdg22.04+1 \
-                sudo=1.9.9-1ubuntu2.4 \
-                tree=2.0.2-1 \
-                vim=2:8.2.3995-1ubuntu2.13 \
+                iputils-ping=3:20240117-1build1 \
+                less=590-2ubuntu2.1 \
+                netcat-traditional=1.10-48 \
+                postgresql-client-16=16.6-0ubuntu0.24.04.1 \
+                sudo=1.9.15p5-3ubuntu5 \
+                tree=2.1.1-2ubuntu3 \
+                vim=2:9.1.0016-1ubuntu7.5 \
                 ; \
         fi; \
         apt-get -yq upgrade; \

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,12 @@ LABKEY_VERSION ?= 21.5-SNAPSHOT
 LABKEY_DISTRIBUTION ?= community
 LABKEY_EK ?= 123abc456
 
+BUILD_ARCHITECTURE ?= linux/amd64
+
 # repo/image:tags must be lowercase
 BUILD_VERSION ?= $(shell      echo '$(LABKEY_VERSION)'      | tr A-Z a-z)
 BUILD_DISTRIBUTION := $(shell echo '$(LABKEY_DISTRIBUTION)' | tr A-Z a-z)
+BUILD_ARCHITECTURE ?= $(BUILD_ARCHITECTURE)
 
 BUILD_REPO_URI ?= $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
 BUILD_REPO_NAME := labkey/$(BUILD_DISTRIBUTION)
@@ -57,6 +60,7 @@ build:
 	docker build \
 		--rm \
 		--compress \
+		--platform $(BUILD_ARCHITECTURE) \
 		$(CACHE_FLAG) \
 		-t $(BUILD_REPO_NAME):latest \
 		-t $(BUILD_LOCAL_TAG) \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ endif
 
 DEBUG ?=
 
-FROM_TAG ?= 17-jre-jammy
+FROM_TAG ?= 17-jre-noble
 
 CACHE_FLAG ?= --no-cache
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -421,6 +421,7 @@ services:
       - JSON_OUTPUT=${JSON_OUTPUT-false}
       - DD_COLLECT_APM=${DD_COLLECT_APM-false}
       - SLEEP=${SLEEP:-0}
+      - PURGE_HEAP_AND_ERROR_LOGS_OLDER_THAN_DAYS=${PURGE_HEAP_AND_ERROR_LOGS_OLDER_THAN_DAYS:-90}
 
   pg-lims_starter:
     image: postgres:15

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,6 +28,9 @@ CSP_ENFORCE="${CSP_ENFORCE:-}"
 DD_COLLECT_APM="${DD_COLLECT_APM:-false}"
 JAVA_RMI_SERVER_HOSTNAME="${JAVA_RMI_SERVER_HOSTNAME:-}"
 
+# set age past which old heap and error log directories are removed
+PURGE_HEAP_AND_ERROR_LOGS_OLDER_THAN_DAYS="${PURGE_HEAP_AND_ERROR_LOGS_OLDER_THAN_DAYS:-90}"
+
 SLEEP="${SLEEP:=0}"
 
 main() {
@@ -263,8 +266,13 @@ main() {
   unset LABKEY_CREATE_INITIAL_USER LABKEY_CREATE_INITIAL_USER_APIKEY LABKEY_INITIAL_USER_APIKEY LABKEY_INITIAL_USER_EMAIL LABKEY_INITIAL_USER_GROUP LABKEY_INITIAL_USER_ROLE
   unset LABKEY_EK SLEEP CONTAINER_PRIVATE_IP
 
-  HEAP_DUMP_PATH="$LABKEY_HOME/files/heap_dumps_$(date +%Y%m%d_%H%M%S)"
-  mkdir -pv $HEAP_DUMP_PATH
+  echo "Creating new heap/error log directory..."
+  HEAP_AND_ERROR_PATH="$LABKEY_HOME/files/heap_dumps_and_errors_$(date +%Y%m%d_%H%M%S)"
+  mkdir -pv $HEAP_AND_ERROR_PATH
+
+  # purge old heap/error directories
+  echo "Purging heap/error log directories older than $PURGE_HEAP_AND_ERROR_LOGS_OLDER_THAN_DAYS days..."
+  find "$LABKEY_HOME/files/" -mindepth 1 -maxdepth 1 -type d -ctime +${PURGE_HEAP_AND_ERROR_LOGS_OLDER_THAN_DAYS} -name "heap*" | xargs rm -rf 
 
   # shellcheck disable=SC2086
   exec java \
@@ -272,13 +280,13 @@ main() {
     -Duser.timezone="${JAVA_TIMEZONE}" \
     \
     -XX:+HeapDumpOnOutOfMemoryError \
-    -XX:HeapDumpPath="${HEAP_DUMP_PATH}" \
+    -XX:HeapDumpPath="${HEAP_AND_ERROR_PATH}" \
     \
     -XX:MaxRAMPercentage="${MAX_JVM_RAM_PERCENT}" \
     \
     -XX:+UseContainerSupport \
     \
-    -XX:ErrorFile="${LABKEY_HOME}/logs/error_%p.log" \
+    -XX:ErrorFile="${HEAP_AND_ERROR_PATH}/error_%p.log" \
     \
     -Djava.net.preferIPv4Stack=true \
     \


### PR DESCRIPTION
#### Rationale
It's time to upgrade from the ubuntu 22.04 eclipse-temurin base image to 24.04.

We also want to repath the java ErrorFile argument to below $LABKEY_HOME/files, as this is commonly mounted to persistent storage outside the container. As heap dumps were already doing this, the heap dump directory has been slightly renamed to contain both heap dumps and error log files. Also added is a purge of old heap (and now error) directories, defaulting to 90+ days old.

As images built on Apple silicon (linux/arm64) are not usable on the linux/amd64 architecture commonly used in ECS, a BUILD_ARCHITECTURE build argument was added, defaulting to linux/amd64.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* eclipse-temurin base image default to noble (ubuntu 24.04)
* set -XX:ErrorFile to below $LABKEY_HOME/files
* BUILD_ARCHITECTURE build arg, default linux/amd64
* PURGE_HEAP_AND_ERROR_LOGS_OLDER_THAN_DAYS env var, default 90 days
