### PR TITLE
comment out CSP set in application.properties, favoring hardcoded policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ This repo contains a Dockerfile, `docker-compose.yml`, and various other files f
 This repo is a work in progress. Containers created from these sources are untested. Until further work is done, integrations with LabKey products that traditionally have relied on OS configuration such as R reports or Python scripts will **NOT** work.
 
 ## Content Security Policy
-February 2025 brings an enforced Content Security Policy enabled by default, the same one that LabKey uses in most if not all deployments, and is highly recommended to be left in place. It can, however, be disabled by enabling the `ExperimentalFeature.disableEnforceCsp` startup property.
+May 2025 brings a stricter Content Security Policy set directly in the LabKey server code (https://github.com/LabKey/server/blob/develop/server/embedded/src/org/labkey/embedded/LabKeyServer.java).
 
-The policy itself can be overriden with an `optional.application.properties` file.
+The policies can still be overridden by setting them in `application.properties`. See the commented out section there for examples.
 
-CSP_REPORT and CSP_ENFORCE environment variables have been removed.
+The default enforce policy can be disabled by enabling the `ExperimentalFeature.disableEnforceCsp` startup property.
 
 ## log4j2.xml
 March 2025 brings a new implementation of log4j2.xml. We're now using the default configuration from the [server repo](https://github.com/LabKey/server/blob/develop/server/embedded/src/main/resources/log4j2.xml), and overriding that as needed with the local file identified in the `LOG4J_CONFIG_OVERRIDE` environment variable. By default this is an empty file that makes no changes, which is due to some complications of the Docker `COPY` command. During startup, entrypoint.sh copies the local files into the configs directory after the jar has been opened up.

--- a/application.properties
+++ b/application.properties
@@ -174,7 +174,7 @@ context.workDirLocation=/work/Tomcat/localhost
 #     script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ; \
 #     base-uri 'self' ; \
 #     frame-src 'self' ${FRAME.SOURCES} ; \
-#     ${UPGRADE.INSECURE.REQUESTS} ; \
+#     ${UPGRADE.INSECURE.REQUESTS} \
 #     frame-ancestors 'self' ; \
 #     report-uri /admin-contentSecurityPolicyReport.api?cspVersion=e12&${CSP.REPORT.PARAMS} ;
 

--- a/application.properties
+++ b/application.properties
@@ -163,5 +163,33 @@ server.tomcat.max-threads=50
 server.servlet.session.timeout=60m
 context.workDirLocation=/work/Tomcat/localhost
 
+## Example CSP Enforce policy
+# csp.enforce=\
+#     default-src 'self' ; \
+#     connect-src 'self' ${CONNECTION.SOURCES} ; \
+#     object-src 'none' ; \
+#     style-src 'self' 'unsafe-inline' ${STYLE.SOURCES} ; \
+#     img-src 'self' data: ${IMAGE.SOURCES} ; \
+#     font-src 'self' data: ${FONT.SOURCES} ; \
+#     script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ; \
+#     base-uri 'self' ; \
+#     frame-src 'self' ${FRAME.SOURCES} ; \
+#     ${UPGRADE.INSECURE.REQUESTS} ; \
+#     frame-ancestors 'self' ; \
+#     report-uri /admin-contentSecurityPolicyReport.api?cspVersion=e12&${CSP.REPORT.PARAMS} ;
+
+## Example CSP Report policy
+# csp.report=\
+#     default-src 'self' ; \
+#     connect-src 'self' ${CONNECTION.SOURCES} ; \
+#     object-src 'none' ; \
+#     style-src 'self' 'unsafe-inline' ${STYLE.SOURCES} ; \
+#     img-src 'self' data: ${IMAGE.SOURCES} ; \
+#     font-src 'self' data: ${FONT.SOURCES} ; \
+#     script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ; \
+#     base-uri 'self' ; \
+#     frame-src 'self' ${FRAME.SOURCES} ; \
+#     report-uri /admin-contentSecurityPolicyReport.api?cspVersion=r12&${CSP.REPORT.PARAMS} ;
+
 ## Load optional application.properties if file exists - used for one-off labkey cloud use cases etc.
 spring.config.import=optional:file:${LABKEY_HOME}/config/optional.application.properties

--- a/application.properties
+++ b/application.properties
@@ -163,36 +163,5 @@ server.tomcat.max-threads=50
 server.servlet.session.timeout=60m
 context.workDirLocation=/work/Tomcat/localhost
 
-## START OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
-csp.enforce=\
-    default-src 'self' https: ; \
-    connect-src 'self' ${CONNECTION.SOURCES} ; \
-    object-src 'none' ; \
-    style-src 'self' https: 'unsafe-inline' ${STYLE.SOURCES} ; \
-    img-src 'self' https: data: ${IMAGE.SOURCES} ; \
-    font-src 'self' data: ${FONT.SOURCES} ; \
-    script-src 'self' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ; \
-    base-uri 'self' ; \
-    upgrade-insecure-requests ;\
-    frame-ancestors 'self' ; \
-    frame-src 'self' ${FRAME.SOURCES} ; \
-    report-uri https://www.labkey.org/admin-contentSecurityPolicyReport.api?cspVersion=e10&${CSP.REPORT.PARAMS} ;
-## END OF CSP ENFORCE BLOCK (DO NOT CHANGE THIS TEXT)
-
-## START OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
-csp.report=\
-    default-src 'self' ;                                                                    /* Limit the default to only the current server */\
-    connect-src 'self' ${CONNECTION.SOURCES} ;                                              /* Limit allowed connection sources */\
-    object-src 'none' ;                                                                     /* These tags are not currently used by LKS */\
-    style-src 'self' 'unsafe-inline' ${STYLE.SOURCES} ;                                     /* We currently have a few inline <style> tags that we are weeding out */\
-    img-src 'self' data: ${IMAGE.SOURCES} ;                                                 /* Limit image loading locations */\
-    font-src 'self' data: ${FONT.SOURCES} ;                                                 /* Limit font source loading locations */\
-    script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}' ;             /* Limit scripts to those with nonces or transitive scripts */\
-    base-uri 'self' ;                                                                       /* Limit the base tags to only source from current server */\
-    frame-ancestors 'self' ;                                                                /* Limit iframe content destinations (who can load this server's content into an iframe) */\
-    frame-src 'self' ${FRAME.SOURCES} ;                                                     /* Limit iframe content sources (from what servers can this server's iframe content be loaded) */\
-    report-uri https://www.labkey.org/admin-contentSecurityPolicyReport.api?cspVersion=r11&${CSP.REPORT.PARAMS} ; /* Report any encountered CSP violations to the supplied URL */
-## END OF CSP REPORT BLOCK (DO NOT CHANGE THIS TEXT)
-
 ## Load optional application.properties if file exists - used for one-off labkey cloud use cases etc.
 spring.config.import=optional:file:${LABKEY_HOME}/config/optional.application.properties

--- a/startup/basic.properties
+++ b/startup/basic.properties
@@ -18,4 +18,6 @@ SiteSettings.sslRequired;startup=true
 SearchSettings.indexFilePath;bootstrap=${LABKEY_FILES_ROOT}/labkey_full_text_index
 SiteSettings.readOnlyHttpRequestTimeout;startup=605
 
+ExperimentalFeature.forwardCspReports;startup=true
+
 ${LABKEY_STARTUP_BASIC_EXTRA}


### PR DESCRIPTION
#### Rationale
Use a strong enforce CSP by default, set in Java code. Remove CSP properties from application.properties files, but leave commented out examples in case users wish to override.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/1065

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
