### PR TITLE
add startup property for issue 53050

### DIFF
--- a/startup/basic.properties
+++ b/startup/basic.properties
@@ -19,5 +19,6 @@ SearchSettings.indexFilePath;bootstrap=${LABKEY_FILES_ROOT}/labkey_full_text_ind
 SiteSettings.readOnlyHttpRequestTimeout;startup=605
 
 ExperimentalFeature.forwardCspReports;startup=true
+ExperimentalFeature.extendedMetrics;startup=true
 
 ${LABKEY_STARTUP_BASIC_EXTRA}


### PR DESCRIPTION
Added startup property to send an list of active users metric. See issue 53050.
ExperimentalFeature.extendedMetrics;startup=true

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53050
and Kanban story
https://github.com/LabKey/kanban/issues/741

Related PR:
https://github.com/LabKey/syseng-chef-server/pull/633