### PR TITLE
fix startup error for missing config/ ; fix JSON logging format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -213,7 +213,7 @@ COPY "startup/${LABKEY_DISTRIBUTION}.properties" \
     startup/49_distribution.properties
 
 # add logging config files
-COPY "${LOG4J_CONFIG_OVERRIDE}" "config/${LOG4J_CONFIG_OVERRIDE}"
+COPY "*.log4j2.xml" "config/"
 
 # add aws cli & make it owned by labkey user so it can all be deleted after s3 downloads in entrypoint.sh
 RUN mkdir -p /usr/src/awsclizip "${LABKEY_HOME}/awsclibin" "${LABKEY_HOME}/aws-cli" \

--- a/README.md
+++ b/README.md
@@ -14,7 +14,18 @@ The policies can still be overridden by setting them in `application.properties`
 The default enforce policy can be disabled by enabling the `ExperimentalFeature.disableEnforceCsp` startup property.
 
 ## log4j2.xml
-March 2025 brings a new implementation of log4j2.xml. We're now using the default configuration from the [server repo](https://github.com/LabKey/server/blob/develop/server/embedded/src/main/resources/log4j2.xml), and overriding that as needed with the local file identified in the `LOG4J_CONFIG_OVERRIDE` environment variable. By default this is an empty file that makes no changes, which is due to some complications of the Docker `COPY` command. During startup, entrypoint.sh copies the local files into the configs directory after the jar has been opened up.
+March 2025 brings a new implementation of log4j2.xml. We're now using the default configuration from the [server repo](https://github.com/LabKey/server/blob/develop/server/embedded/src/main/resources/log4j2.xml), and overriding that as needed with the local file identified in the `LOG4J_CONFIG_OVERRIDE` environment variable. By default this is an empty file that makes no changes, which is due to some complications of the Docker `COPY` command. Any *.log4j2.xml files in the root dir will be copied to the config/ folder in the image when built, which end up in /labkey/config in a running container.
+
+LabKey deployments use the included `labkey.log4j2.xml` to override the server default config, mostly just to set JSON format for console output.
+
+Here are some example env var combinations and their effects:
+
+| env var                                                                           | result                                                                                                               |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------                                                               |
+| JSON_OUTPUT=true                                                                  | uses `labkey.log4j2.xml` to set JSON format console output                                                           |
+| LOG4J_CONFIG_OVERRIDE="labkey.log4j2.xml"                                         | same as above                                                                                                        |
+| LOG4J_CONFIG_FILE="example.log4j2.xml"                                            | assumes you built your own image with `example.log4j2.xml` in the root dir, and uses that instead of server defaults |
+| LOG4J_CONFIG_FILE="example.log4j2.xml" LOG4J_CONFIG_OVERRIDE="labkey.log4j2.xml"  | same as above, but also overrides `example.log4j2.xml` with contents of `labkey.log4j2.xml`                          |
 
 ## Upgrading from 23.11 to 24.3
 March 2024 saw [many changes](https://github.com/LabKey/Dockerfile/commits/24.3.0) in an effort to bring this repo in line with LabKey server versioning/releases, starting with v24.3, in which the embedded tomcat version has been upgraded from 9 to 10. 

--- a/application.properties
+++ b/application.properties
@@ -12,10 +12,6 @@ spring.main.banner-mode=off
 spring.application.name=labkey
 server.servlet.application-display-name=labkey
 
-# 2024-02-29 - if enabling logging.config setting, the file must exist at runtime or app will error and quit
-#            - if logging.config and LOG4J_CONFIG_FILE env var are set differently, LOG4J_CONFIG_FILE wins
-# logging.config=${$LOG4J_CONFIG_FILE:log4j2.xml}
-
 # logging.pattern.console=
 logging.pattern.console=%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} E %clr(%-5.5p) %clr(%5.5replace(%p){'.+', ${PID:-}}){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(${LOGGER_PATTERN:-%-40.40logger{39}}){cyan} %clr(:){faint} %m%n%wEx
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -224,14 +224,18 @@ main() {
 
   sed -i "s/@@encryptionKey@@/${LABKEY_EK}/" config/application.properties
 
-  # TODO: do we need the JSON check anymore? should we just take the override if it is set?
-  # Check if we want JSON output, we are using the base log4j2.xml config, and have an override config to use
-  if [ "${JSON_OUTPUT}" = "true" ] && [ "${LOG4J_CONFIG_FILE}" = "log4j2.xml" ] && [ -s "config/${LOG4J_CONFIG_OVERRIDE}" ]; then
-    echo "JSON_OUTPUT==true && LOG4J_CONFIG_FILE==log4j2.xml && LOG4J_CONFIG_OVERRIDE is set, so updating application.properties and log4j2.xml to output JSON to console"
+  # Check if we want JSON output, we are using the base log4j2.xml config
+  if [ "${JSON_OUTPUT}" = "true" ] && [ "${LOG4J_CONFIG_FILE}" = "log4j2.xml" ]; then
+    echo "JSON_OUTPUT==true && LOG4J_CONFIG_FILE==log4j2.xml, so using the base log4j2.xml with labkey.log4j2.xml overrides, to send JSON output to console"
+    LOG4J_CONFIG_FILE="log4j2.xml, config/labkey.log4j2.xml"
+    echo "Log4j configuration files: $LOG4J_CONFIG_FILE"
+  # if the override file exists and isn't empty, use that to override whatever was set in LOG4J_CONFIG_FILE (which might still be server default of log4j2.xml)
+  elif [ -f "config/${LOG4J_CONFIG_OVERRIDE}" ] && [ -s "config/${LOG4J_CONFIG_OVERRIDE}" ]; then
+    echo "LOG4J_CONFIG_OVERRIDE==${LOG4J_CONFIG_OVERRIDE}, so using that to override default settings in LOG4J_CONFIG_FILE (${LOG4J_CONFIG_FILE})"
     LOG4J_CONFIG_FILE="${LOG4J_CONFIG_FILE:=log4j2.xml},config/${LOG4J_CONFIG_OVERRIDE}"
     echo "Log4j configuration files: $LOG4J_CONFIG_FILE"
   else
-    echo "saw JSON_OUTPUT=$JSON_OUTPUT and LOG4J_CONFIG_FILE=$LOG4J_CONFIG_FILE and LOG4J_CONFIG_OVERRIDE=$LOG4J_CONFIG_OVERRIDE"
+    echo "saw JSON_OUTPUT=$JSON_OUTPUT and LOG4J_CONFIG_FILE=$LOG4J_CONFIG_FILE and LOG4J_CONFIG_OVERRIDE=$LOG4J_CONFIG_OVERRIDE (which, if defined, was empty)"
   fi
 
   export DD_JAVA_AGENT=""

--- a/labkey.log4j2.xml
+++ b/labkey.log4j2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<Configuration packages="org.labkey.api.util,org.labkey.embedded">
+<Configuration>
 
     <Appenders>
         <Console name="CONSOLE" target="SYSTEM_OUT">

--- a/quickstart_envs.sh
+++ b/quickstart_envs.sh
@@ -3,7 +3,7 @@
 # example minimal set of environment variables to get started - see readme for additional envs you may wish to set
 
 # embedded tomcat LabKey .jar version to build container with
-export LABKEY_VERSION="25.3"
+export LABKEY_VERSION="25.7"
 
 # minimal SMTP settings
 export SMTP_HOST="localhost"


### PR DESCRIPTION
#### Rationale
* [52974](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52974), error about " /config is a directory", due to incomplete bash test . `[ -s "config/${LOG4J_CONFIG_OVERRIDE}" ]` would succeed if the var wasn't defined (because -s passes if the dir exists), but later what was supposed to be a file is only a dir, so it throws the error. Now it'll be a -f and a -s test

* JSON logging has been broken for a while, because our deployments should be using the `labkey.log4j2.xml` when JSON_OUTPUT=true, but were not.

* labkey.log4j2.xml also needed updating to match changes in https://github.com/LabKey/server/pull/1069 

#### Related Pull Requests
* https://github.com/LabKey/server/pull/1069
* https://github.com/LabKey/Dockerfile/pull/136

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
