### PR TITLE
add override block to turn audit logs off by default

### DIFF
--- a/labkey.log4j2.xml
+++ b/labkey.log4j2.xml
@@ -38,9 +38,9 @@
         </Logger>
 
         <!-- Override the audit log behavior -->
-<!--        <Logger name="org.labkey.audit.event" additivity="false" level="OFF">-->
-<!--            <AppenderRef ref="LABKEY_AUDIT"/>-->
-<!--            <AppenderRef ref="CONSOLE" />-->
-<!--        </Logger>-->
+       <Logger name="org.labkey.audit.event" additivity="false" level="OFF">
+            <AppenderRef ref="LABKEY_AUDIT"/>
+            <AppenderRef ref="CONSOLE" />
+        </Logger>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
#### Rationale
due to conflicts with EC2 deployment overrides, we're commenting out the block in the server's default log4j config that turns audit logs off by default. This adds that directive back in as an override for our ECS deployments.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/1113

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
