### PR TITLE
only force default aws account/region env vars if not already set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ IDENT ?= labkey
 PULL_TAG ?= latest
 
 ifeq ($(AWS_ACCESS_KEY_ID),)
-	AWS_ACCOUNT_ID=123456789
-	AWS_REGION=us-west-2
+	AWS_ACCOUNT_ID ?= 123456789
+	AWS_REGION ?= us-west-2
 else
 	AWS_ACCOUNT_ID ?= $(shell aws sts get-caller-identity | jq -r '.Account' | grep -E '[0-9]{12}' || exit 1)
 	AWS_REGION ?= $(shell aws configure get region || exit 1)


### PR DESCRIPTION
#### Rationale
a check for 'AWS_ACCESS_KEY_ID' was added to force default/fake values for aws account and region, to allow vanilla `make build` to succeed without worrying about aws credentials, but the plain `=` used meant valid AWS_ACCOUNT_ID and AWS_REGION env vars were being overwritten if AWS_ACCESS_KEY_ID was not also set. Changing to `?=` fixes this bug.

#### Related Pull Requests
* https://github.com/LabKey/Dockerfile/pull/163

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
