### PR TITLE
fix log4j config logic 

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -29,32 +29,14 @@ logging.level.sql=${LOG_LEVEL_SQL}
 
 logging.level.net.sf.ehcache=ERROR
 
-# logging.level.org.apache=TRACE
-# logging.level.org.apache.catalina.core.Catalina=TRACE
 logging.level.org.apache.catalina.core.ContainerBase.[Tomcat].[localhost]=TRACE
-# logging.level.org.apache.catalina.core=TRACE
-# logging.level.org.apache.catalina.LifecycleException=TRACE
+
 logging.level.org.apache.catalina.loader.WebappClassLoaderBase=OFF
-# logging.level.org.apache.catalina.session=TRACE
-# logging.level.org.apache.catalina.startup.ContextConfig=OFF
-# logging.level.org.apache.catalina.util.LifecycleBase=TRACE
-# logging.level.org.apache.catalina.util=TRACE
-# logging.level.org.apache.catalina=TRACE
-# logging.level.org.apache.coyote=TRACE
-# logging.level.org.apache.logging.log4j.core.net=TRACE
-# logging.level.org.apache.naming=OFF
+
 logging.level.org.apache.tomcat.util.IntrospectionUtils=OFF
-# logging.level.org.apache.tomcat.util.net=TRACE
 logging.level.org.apache.tomcat.util.scan=OFF
-# logging.level.org.apache.tomcat.util=TRACE
 logging.level.org.labkey.embedded.LabKeyServer=DEBUG
 logging.level.org.springframework.boot.autoconfigure.logging.ConditionEvaluationReportLoggingListener=OFF
-# logging.level.org.springframework.boot.autoconfigure=OFF
-# logging.level.org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainer=TRACE
-# logging.level.org.springframework.boot.web.embedded.tomcat.TomcatWebServer=TRACE
-# logging.level.org.springframework.boot.web.servlet.context=TRACE
-# logging.level.org.springframework.boot.web.servlet=WARN
-#logging.level.org.springframework.boot=INFO
 
 logging.level.org.springframework.jdbc.core=WARN
 logging.level.org.hibernate.SQL=WARN

--- a/application.properties
+++ b/application.properties
@@ -12,50 +12,6 @@ spring.main.banner-mode=off
 spring.application.name=labkey
 server.servlet.application-display-name=labkey
 
-# logging.pattern.console=
-logging.pattern.console=%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} E %clr(%-5.5p) %clr(%5.5replace(%p){'.+', ${PID:-}}){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(${LOGGER_PATTERN:-%-40.40logger{39}}){cyan} %clr(:){faint} %m%n%wEx
-
-logging.level.root=WARN
-
-# custom tomcat group
-logging.group.tomcat=org.apache.catalina, org.apache.coyote, org.apache.tomcat
-logging.level.tomcat=${LOG_LEVEL_TOMCAT}
-
-logging.level.org.apache.coyote.http2=OFF
-
-# default groups
-logging.level.web=${LOG_LEVEL_SPRING_WEB}
-logging.level.sql=${LOG_LEVEL_SQL}
-
-logging.level.net.sf.ehcache=ERROR
-
-logging.level.org.apache.catalina.core.ContainerBase.[Tomcat].[localhost]=TRACE
-
-logging.level.org.apache.catalina.loader.WebappClassLoaderBase=OFF
-
-logging.level.org.apache.tomcat.util.IntrospectionUtils=OFF
-logging.level.org.apache.tomcat.util.scan=OFF
-logging.level.org.labkey.embedded.LabKeyServer=DEBUG
-logging.level.org.springframework.boot.autoconfigure.logging.ConditionEvaluationReportLoggingListener=OFF
-
-logging.level.org.springframework.jdbc.core=WARN
-logging.level.org.hibernate.SQL=WARN
-logging.level.org.jooq.tools.LoggerListener=WARN
-logging.level.org.springframework.core.codec=WARN
-logging.level.org.springframework.http=WARN
-logging.level.org.springframework.web=WARN
-logging.level.org.springframework.boot.actuate.endpoint.web=WARN
-logging.level.org.springframework.boot.web.servlet.ServletContextInitializerBeans=WARN
-logging.level.org.springframework.boot=WARN
-
-# logging.level.org.apache.catalina.loader.WebappClassLoaderBase=INFO
-logging.level.org.apache.jasper.servlet.TldScanner=WARN
-logging.level.org.apache.tomcat.util.digester.Digester=INFO
-
-# logging.level.org.apache.tomcat.util.scan.StandardJarScanner=INFO
-# logging.level.org.springframework.boot.autoconfigure.condition=INFO
-# logging.level.org.springframework.core.env.PropertySourcesPropertyResolver=INFO
-
 context.resources.jdbc.labkeyDataSource.type=javax.sql.DataSource
 context.resources.jdbc.labkeyDataSource.driverClassName=org.postgresql.Driver
 # context.resources.jdbc.labkeyDataSource.url=jdbc:postgresql://${POSTGRES_HOST:-localhost}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-${POSTGRES_USER}}${POSTGRES_PARAMETERS:-}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,6 @@ LABKEY_CUSTOM_PROPERTIES_S3_URI="${LABKEY_CUSTOM_PROPERTIES_S3_URI:=none}"
 LABKEY_OPTIONAL_APP_PROPERTIES_S3_URI="${LABKEY_OPTIONAL_APP_PROPERTIES_S3_URI:=none}"
 LABKEY_DEFAULT_PROPERTIES_S3_URI="${LABKEY_DEFAULT_PROPERTIES_S3_URI:=none}"
 
-# set below to 'labkeywebapp/WEB-INF/classes/log4j2.xml' to use embedded tomcat version from the built .jar
 LOG4J_CONFIG_FILE="${LOG4J_CONFIG_FILE:=log4j2.xml}"
 
 # below assumes using local log4j2.xml file, as the embedded version is not available for edits until after server is running
@@ -226,19 +225,21 @@ main() {
 
   sed -i "s/@@encryptionKey@@/${LABKEY_EK}/" config/application.properties
 
-  # Check if we want JSON output, we are using the base log4j2.xml config
+  # Check if we want JSON output, and/or if we are using the base log4j2.xml config
+  export LOG4J_CONFIG_OPTION=""
   if [ "${JSON_OUTPUT}" = "true" ] && [ "${LOG4J_CONFIG_FILE}" = "log4j2.xml" ]; then
     echo "JSON_OUTPUT==true && LOG4J_CONFIG_FILE==log4j2.xml, so using the base log4j2.xml with labkey.log4j2.xml overrides, to send JSON output to console"
-    LOG4J_CONFIG_FILE="log4j2.xml, config/labkey.log4j2.xml"
-    echo "Log4j configuration files: $LOG4J_CONFIG_FILE"
+    export LOG4J_CONFIG_OPTION="-Dlog4j.configurationFile=log4j2.xml,config/labkey.log4j2.xml"
   # if the override file exists and isn't empty, use that to override whatever was set in LOG4J_CONFIG_FILE (which might still be server default of log4j2.xml)
   elif [ -f "config/${LOG4J_CONFIG_OVERRIDE}" ] && [ -s "config/${LOG4J_CONFIG_OVERRIDE}" ]; then
     echo "LOG4J_CONFIG_OVERRIDE==${LOG4J_CONFIG_OVERRIDE}, so using that to override default settings in LOG4J_CONFIG_FILE (${LOG4J_CONFIG_FILE})"
-    LOG4J_CONFIG_FILE="${LOG4J_CONFIG_FILE:=log4j2.xml},config/${LOG4J_CONFIG_OVERRIDE}"
-    echo "Log4j configuration files: $LOG4J_CONFIG_FILE"
-  else
+    export LOG4J_CONFIG_OPTION="-Dlog4j.configurationFile=${LOG4J_CONFIG_FILE:=log4j2.xml},config/${LOG4J_CONFIG_OVERRIDE}"
+  elif [ "${LOG4J_CONFIG_FILE}" = "log4j2.xml" ]; then
     echo "saw JSON_OUTPUT=$JSON_OUTPUT and LOG4J_CONFIG_FILE=$LOG4J_CONFIG_FILE and LOG4J_CONFIG_OVERRIDE=$LOG4J_CONFIG_OVERRIDE (which, if defined, was empty)"
+    echo "... so configuring nothing for LOG4J_CONFIG_OPTION"
   fi
+
+  echo "Log4j configuration option(s): $LOG4J_CONFIG_OPTION"
 
   export DD_JAVA_AGENT=""
   export DD_JMX=""
@@ -315,7 +316,7 @@ main() {
     -Dlogback.debug="$debug_string" \
     \
     -Dlog4j.debug="$debug_string" \
-    -Dlog4j.configurationFile="$LOG4J_CONFIG_FILE" \
+    ${LOG4J_CONFIG_OPTION} \
     \
     -Dorg.apache.catalina.startup.EXIT_ON_INIT_FAILURE=true \
     \

--- a/quickstart_envs.sh
+++ b/quickstart_envs.sh
@@ -3,7 +3,7 @@
 # example minimal set of environment variables to get started - see readme for additional envs you may wish to set
 
 # embedded tomcat LabKey .jar version to build container with
-export LABKEY_VERSION="26.1"
+export LABKEY_VERSION="26.2"
 
 # minimal SMTP settings
 export SMTP_HOST="localhost"


### PR DESCRIPTION
#### Rationale
log4j config setup would throw an error if json logging wasn't enabled, `log4j.configurationFile must be in the form log4j2.xml[,secondaryFile]`. Leaving the -D option out entirely if we don't need it avoids this.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* log4j config fix
* remove commented out legacy logging options from application.properties
* bump to v26.2
