### PR TITLE
bump curl version to 8.5.0-2ubuntu10.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,7 @@ RUN [ -n "${DEBUG}" ] && set -x; \
         export DEBIAN_FRONTEND=noninteractive; \
         apt-get update; \
         apt-get -yq --no-install-recommends install \
-            curl=8.5.0-2ubuntu10.7 \
+            curl=8.5.0-2ubuntu10.8 \
             openssl \
             gettext-base=0.21-14ubuntu2 \
             unzip=6.0-28ubuntu4.1 \

--- a/quickstart_envs.sh
+++ b/quickstart_envs.sh
@@ -3,7 +3,7 @@
 # example minimal set of environment variables to get started - see readme for additional envs you may wish to set
 
 # embedded tomcat LabKey .jar version to build container with
-export LABKEY_VERSION="26.2"
+export LABKEY_VERSION="26.3"
 
 # minimal SMTP settings
 export SMTP_HOST="localhost"


### PR DESCRIPTION
#### Rationale
CVE patching bumped the curl version: https://launchpad.net/ubuntu/noble/+source/curl/+changelog

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
