### PR TITLE
bump curl to 8.5.0-2ubuntu10.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,7 @@ RUN [ -n "${DEBUG}" ] && set -x; \
         export DEBIAN_FRONTEND=noninteractive; \
         apt-get update; \
         apt-get -yq --no-install-recommends install \
-            curl=8.5.0-2ubuntu10.8 \
+            curl=8.5.0-2ubuntu10.9 \
             openssl \
             gettext-base=0.21-14ubuntu2 \
             unzip=6.0-28ubuntu4.1 \


### PR DESCRIPTION
#### Rationale
bump curl to 8.5.0-2ubuntu10.9 on snapshot branch 
#### Related Pull Requests
* https://github.com/LabKey/Dockerfile/pull/176
