### PR TITLE
bump curl to 8.5.0-2ubuntu10.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,7 @@ RUN [ -n "${DEBUG}" ] && set -x; \
         export DEBIAN_FRONTEND=noninteractive; \
         apt-get update; \
         apt-get -yq --no-install-recommends install \
-            curl=8.5.0-2ubuntu10.8 \
+            curl=8.5.0-2ubuntu10.9 \
             openssl \
             gettext-base=0.21-14ubuntu2 \
             unzip=6.0-28ubuntu4.1 \


### PR DESCRIPTION
## Summary
- Cherry-pick of curl version bump from PR #177 (`release26.5-SNAPSHOT`) into `release26.3-SNAPSHOT`
- Bumps curl from `8.5.0-2ubuntu10.8` → `8.5.0-2ubuntu10.9`

## Test plan
- [x] Verify Docker build succeeds with updated curl version

🤖 Generated with [Claude Code](https://claude.com/claude-code)