### PR TITLE
Fix Docker health check endpoint for Spring Boot 4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -234,7 +234,7 @@ ENV HEALTHCHECK_INTERVAL="6s" \
     HEALTHCHECK_SECURITY_FLAG="-k" \
     HEALTHCHECK_EXTRA_FLAGS="-s" \
     \
-    HEALTHCHECK_ENDPOINT="/_/health"
+    HEALTHCHECK_ENDPOINT="/admin-healthcheck.api"
 
 HEALTHCHECK \
     --interval=5s \


### PR DESCRIPTION
## Summary
- `/_/health` relied on `spring-boot-actuator`, which is not bundled in Spring Boot 4 (upgraded in LabKey/server#1260, January 2026)
- Switches `HEALTHCHECK_ENDPOINT` to `/admin-healthcheck.api`, a LabKey-native endpoint returning `{"healthy":true}` with no auth required
- Matches the endpoint already in use by production ALB target group health checks

## Test plan
- [x] Build image and verify `docker inspect --format='{{.State.Health.Status}}'` reports `healthy`
- [x] Confirm `/admin-healthcheck.api` returns `{"healthy":true}` on a running container

🤖 Generated with [Claude Code](https://claude.com/claude-code)