### PR TITLE
Unpin apt/apk package versions to fix periodic build failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,10 @@ COPY entrypoint.sh /entrypoint.sh
 
 WORKDIR "${LABKEY_HOME}"
 
+# OS packages below are intentionally NOT version-pinned. The `apt-get upgrade` / `apk upgrade`
+# steps in the RUN pull latest-patched versions anyway, and exact pins get rotated out of the
+# distro archive on each security update, breaking builds. Signed repo metadata — not the
+# version string — is the supply-chain control. This is why DL3008/DL3018 are ignored below.
 # hadolint ignore=DL4006,DL3008,DL3018
 RUN [ -n "${DEBUG}" ] && set -x; \
     set -eu; \
@@ -123,11 +127,11 @@ RUN [ -n "${DEBUG}" ] && set -x; \
         apk update \
         && apk add --no-cache \
             openssl \
-            gettext=0.21.1-r7 \
-            unzip=6.0-r14 \
-            curl=8.1.2-r0 \
+            gettext \
+            unzip \
+            curl \
             ; \
-        [ -n "${DEBUG}" ] && apk add --no-cache tree=2.1.1-r0; \
+        [ -n "${DEBUG}" ] && apk add --no-cache tree; \
         apk upgrade; \
         \
         addgroup -S labkey \
@@ -144,22 +148,22 @@ RUN [ -n "${DEBUG}" ] && set -x; \
         export DEBIAN_FRONTEND=noninteractive; \
         apt-get update; \
         apt-get -yq --no-install-recommends install \
-            curl=8.5.0-2ubuntu10.9 \
+            curl \
             openssl \
-            gettext-base=0.21-14ubuntu2 \
-            unzip=6.0-28ubuntu4.1 \
-            wget=1.21.4-1ubuntu4.1 \
+            gettext-base \
+            unzip \
+            wget \
             ; \
         if [ -n "${DEBUG}" ]; then \
             apt-get update; \
             apt-get -yq --no-install-recommends install \
-                iputils-ping=3:20240117-1ubuntu0.1 \
-                less=590-2ubuntu2.1 \
-                netcat-traditional=1.10-48 \
-                postgresql-client-16=16.10-0ubuntu0.24.04.1 \
-                sudo=1.9.15p5-3ubuntu5.24.04.1 \
-                tree=2.1.1-2ubuntu3.24.04.2 \
-                vim=2:9.1.0016-1ubuntu7.9 \
+                iputils-ping \
+                less \
+                netcat-traditional \
+                postgresql-client-16 \
+                sudo \
+                tree \
+                vim \
                 ; \
         fi; \
         apt-get -yq upgrade; \


### PR DESCRIPTION
## Problem

The nightly builds (e.g. LimsStarterContainerNightly) periodically fail because the `Dockerfile` pins exact OS package versions like `curl=8.5.0-2ubuntu10.9`. Ubuntu's `noble` archive (and Alpine's) keeps only the *latest* build of each package — when a security update bumps a package, the old exact version is deleted from the repo, so `apt-get install curl=8.5.0-2ubuntu10.9` fails with a one-line `E: Version '…' was not found` buried deep in the build log.

## Why removing the pins is the right fix

- **The pins weren't doing anything.** The `RUN` runs `apt-get -yq upgrade` / `apk upgrade` immediately after the pinned installs, which bump those same packages to latest anyway. So the running image was already on latest-patched versions, not the pinned ones — the pins provided no reproducibility.
- **No supply-chain loss.** apt/apk's signed repo metadata is what verifies packages, not the version string. Version pinning ≠ a hash-level supply-chain control.
- **CVE posture is unchanged/better.** `apt-get upgrade` (kept) is the actual CVE-patching mechanism for the whole base-image package set — important for the xeol/dockle scans.
- **Lint stays clean.** hadolint DL3008/DL3018 (require-pinning) were already in the ignore directive; they now correctly suppress the unpinned-version warnings. An intent comment was added so nobody re-pins later.

Removing the pins also eliminates the misleading buried "Version not found" error entirely.

## Changes

`Dockerfile` only — stripped the `=<version>` suffix from the apt (`curl`, `gettext-base`, `unzip`, `wget` + DEBUG-only set) and apk (`gettext`, `unzip`, `curl`, `tree`) packages. `postgresql-client-16` keeps its name (the `-16` is the Postgres major, not a pin). Kept both `upgrade` steps.

## Verification

- `hadolint` — clean
- `LABKEY_DISTRIBUTION=lims_starter make build` (noble) — ✅
- `DEBUG=1 LABKEY_DISTRIBUTION=community make build` — ✅ (extra apt pkgs)
- `FROM_TAG=25-jre-alpine make build` — ✅ (apk path)
- `make test` (smoke) — ✅ `smoke test succeeded` (LabKey booted, curl healthcheck OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)